### PR TITLE
Bug Fix: call subscriptions with initial model, fixes #10

### DIFF
--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -42,7 +42,7 @@ export function program<model, msg>(
     .distinctUntilChanged(modelCompare)
     .map(state => state[0])
     .share()
-  const sub$ = model$.switchMap(model => subscriptions(model))
+  const sub$ = model$.startWith(init[0]).switchMap(model => subscriptions(model))
   return { dispatch, cmd$, sub$, model$ }
 }
 


### PR DESCRIPTION
This seems like a hacky way to fix #10.

The issue seems to be somewhere in calling `share()` on `model$` stream, and subscribing to it with two streams `html$` and `sub$` where the second one is built with `switchMap`. 
Without change from this PR, subscriptions function passed to `model$.switchMap` does not get called with initial model.

Few more observations:
1. If `share()` method call is removed on `model$` stream, subscriptions function is called with initial model. That leads to undesired behavior where calling modelCompare and mapping of state to model happens twice, which was surely the reason to introduce `share()`.
2. If `html$` subscription is removed and `sub$` remains the only subscription to `model$`, subscriptions function is called with initial model.

With my limited knowledge of `rxjs` this was the only fix I could find, which has no undesired behavior changes.