### PR TITLE
fix return type of programWithDebugger in order to comply to Html's program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
-# 0.5.1
+## 0.5.2
+
+- **Bug Fix:**
+  - fix return type of `programWithDebugger` in order to comply to `Html`'s `program` (@StefanoMagrassi)
+
+## 0.5.1
 
 - **Breaking Change**
   - upgrade to `fp-ts@2.x` (@gcanti)
@@ -46,19 +51,19 @@ high state of flux, you're at risk of it changing without notice.
   - Full tests coverage (@StefanoMagrassi)
   - switch from `Mocha` to `Jest` as test runner (@StefanoMagrassi)
 
-# 0.4.3
+## 0.4.3
 
 - **Bug Fix**
   - don't rely on `instanceof Error` while matching axios errors, closes #23 (@minedeljkovic)
 
-# 0.4.1
+## 0.4.1
 
 - **New Feature**
   - expose `http.requestToTask` as `toTask` (@minedeljkovic)
 - **Polish**
   - remove `react-dom` dependency (@gcanti)
 
-# 0.4.0
+## 0.4.0
 
 - **Breaking Change**
   - remove `Reader` from `Html` signature (@minedeljkovic)
@@ -72,20 +77,20 @@ high state of flux, you're at risk of it changing without notice.
   - add `React.map` function (@minedeljkovic)
   - add `Sub.map` function (@minedeljkovic)
 
-# 0.3.1
+## 0.3.1
 
 - **Bug Fix**
   - call subscriptions with initial model, fix #10 (@minedeljkovic)
 
-# 0.3.0
+## 0.3.0
 
 - **Breaking Change**
   - upgrade to `fp-ts@1.x.x`, `io-ts@1.x.x` (@gcanti)
 
-# 0.2.0
+## 0.2.0
 
 Refactoring
 
-# 0.1.0
+## 0.1.0
 
 Initial release

--- a/docs/modules/Debug/index.ts.md
+++ b/docs/modules/Debug/index.ts.md
@@ -70,11 +70,11 @@ or applying a message with:
 
 ```ts
 export function programWithDebugger<Model, Msg, Dom>(
-  init: [Model, cmd.Cmd<Msg>],
-  update: (msg: Msg, model: Model) => [Model, cmd.Cmd<Msg>],
+  init: [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
   view: (model: Model) => Html<Dom, Msg>,
   subscriptions?: (model: Model) => Sub<Msg>
-): Program<Model, MsgWithDebug<Model, Msg>, Dom> { ... }
+): Program<Model, Msg, Dom> { ... }
 ```
 
 Added in v0.5.0
@@ -87,11 +87,11 @@ Same as `programWithDebugger()` but with `Flags` that can be passed when the `Pr
 
 ```ts
 export function programWithDebuggerWithFlags<Flags, Model, Msg, Dom>(
-  init: (flags: Flags) => [Model, cmd.Cmd<Msg>],
-  update: (msg: Msg, model: Model) => [Model, cmd.Cmd<Msg>],
+  init: (flags: Flags) => [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
   view: (model: Model) => Html<Dom, Msg>,
   subscriptions?: (model: Model) => Sub<Msg>
-): (flags: Flags) => Program<Model, MsgWithDebug<Model, Msg>, Dom> { ... }
+): (flags: Flags) => Program<Model, Msg, Dom> { ... }
 ```
 
 Added in v0.5.0

--- a/examples/Debugger.tsx
+++ b/examples/Debugger.tsx
@@ -1,0 +1,10 @@
+import { render } from 'react-dom'
+import { programWithDebugger } from '../src/Debug'
+import * as React from '../src/React'
+import * as component from './Counter'
+
+const program = process.env.NODE_ENV === 'production' ? React.program : programWithDebugger
+
+const main = program(component.init, component.update, component.view)
+
+React.run(main, dom => render(dom, document.getElementById('app')))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-ts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-ts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A porting of TEA to TypeScript featuring fp-ts, rxjs6 and React",
   "files": [
     "lib",

--- a/src/Debug/index.ts
+++ b/src/Debug/index.ts
@@ -30,7 +30,7 @@ import { IO, chain, map } from 'fp-ts/lib/IO'
 import { fold } from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
 import { BehaviorSubject } from 'rxjs'
-import * as cmd from '../Cmd'
+import { Cmd, none } from '../Cmd'
 import { Html, Program, program } from '../Html'
 import { Sub } from '../Sub'
 import { DebugData, DebuggerR, Global, MsgWithDebug, debugInit, debugMsg } from './commons'
@@ -61,25 +61,25 @@ import { getConnection, reduxDevToolDebugger } from './redux-devtool'
  * @since 0.5.0
  */
 export function programWithDebugger<Model, Msg, Dom>(
-  init: [Model, cmd.Cmd<Msg>],
-  update: (msg: Msg, model: Model) => [Model, cmd.Cmd<Msg>],
+  init: [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
   view: (model: Model) => Html<Dom, Msg>,
   subscriptions?: (model: Model) => Sub<Msg>
-): Program<Model, MsgWithDebug<Model, Msg>, Dom> {
+): Program<Model, Msg, Dom> {
   const debug = runDebugger<Model, Msg>(window)
 
   const initModel = init[0]
 
   const data$ = new BehaviorSubject<DebugData<Model, Msg>>([debugInit(), initModel])
 
-  const updateWithDebug = (msg: MsgWithDebug<Model, Msg>, model: Model): [Model, cmd.Cmd<Msg>] => {
+  const updateWithDebug = (msg: MsgWithDebug<Model, Msg>, model: Model): [Model, Cmd<Msg>] => {
     if ('type' in msg) {
       switch (msg.type) {
         case '__DebugUpdateModel__':
-          return [msg.payload, cmd.none]
+          return [msg.payload, none]
 
         case '__DebugApplyMsg__':
-          return [update(msg.payload, model)[0], cmd.none]
+          return [update(msg.payload, model)[0], none]
       }
     }
 
@@ -90,10 +90,12 @@ export function programWithDebugger<Model, Msg, Dom>(
     return result
   }
 
-  const p = program<Model, MsgWithDebug<Model, Msg>, Dom>(init, updateWithDebug, view, subscriptions)
+  const p = program(init, updateWithDebug, view, subscriptions)
 
   // --- Run the debugger
-  debug({ data$, init: initModel, dispatch: p.dispatch })()
+  // --- we need to make a type assertion for `dispatch` because we cannot change the intrinsic `msg` type of `program`;
+  // --- otherwise `programWithDebugger` won't be usable as a transparent extension/substitution of `Html`'s programs
+  debug({ data$, init: initModel, dispatch: p.dispatch as DebuggerR<Model, Msg>['dispatch'] })()
 
   return p
 }
@@ -103,11 +105,11 @@ export function programWithDebugger<Model, Msg, Dom>(
  * @since 0.5.0
  */
 export function programWithDebuggerWithFlags<Flags, Model, Msg, Dom>(
-  init: (flags: Flags) => [Model, cmd.Cmd<Msg>],
-  update: (msg: Msg, model: Model) => [Model, cmd.Cmd<Msg>],
+  init: (flags: Flags) => [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
   view: (model: Model) => Html<Dom, Msg>,
   subscriptions?: (model: Model) => Sub<Msg>
-): (flags: Flags) => Program<Model, MsgWithDebug<Model, Msg>, Dom> {
+): (flags: Flags) => Program<Model, Msg, Dom> {
   return flags => programWithDebugger(init(flags), update, view, subscriptions)
 }
 

--- a/test/Debug/Debug.test.ts
+++ b/test/Debug/Debug.test.ts
@@ -24,10 +24,12 @@ describe('Debug', () => {
     const program = programWithDebugger(init, update, view)
 
     program.dispatch({ tag: 'Inc' })
-    program.dispatch({ type: '__DebugUpdateModel__', payload: 10 })
+    // we need to cast as any to test internal handling of this "special" message
+    program.dispatch({ type: '__DebugUpdateModel__', payload: 10 } as any)
     program.dispatch({ tag: 'Dec' })
     program.dispatch({ tag: 'Inc' })
-    program.dispatch({ type: '__DebugApplyMsg__', payload: { tag: 'Inc' } })
+    // we need to cast as any to test internal handling of this "special" message
+    program.dispatch({ type: '__DebugApplyMsg__', payload: { tag: 'Inc' } } as any)
     program.dispatch({ tag: 'Inc' })
 
     assert.strictEqual(log.length, 5)
@@ -56,7 +58,8 @@ describe('Debug', () => {
     const program = programWithDebugger(init, update, view, subscription)
 
     program.dispatch({ tag: 'Inc' })
-    program.dispatch({ type: '__DebugUpdateModel__', payload: 10 })
+    // we need to cast as any to test internal handling of this "special" message
+    program.dispatch({ type: '__DebugUpdateModel__', payload: 10 } as any)
     program.dispatch({ tag: 'Dec' })
     program.dispatch({ tag: 'Inc' })
     program.dispatch({ tag: 'Inc' })


### PR DESCRIPTION
This PR fix the return type of `programWithDebugger`.

Withe the previous declaration `programWithDebugger` could not be used as a substitution to standard `program` in development environment because the message types didn't match.