### PR TITLE
Debugger specialization for Navigation programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+## 0.5.3
+
+- **New Feature**
+  - `Debugger` specialization for `Navigation` programs (@StefanoMagrassi)
+
 ## 0.5.2
 
 - **Bug Fix:**

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ function fromCodec<A>(codec: t.Decoder<unknown, A>): Decoder<A> {
 
 ## Enable debugger in development mode
 
+For `Html` (and its specializations) programs:
+
 ```ts
-import { programWithDebugger } from 'elm-ts/lib/Debug'
+import { programWithDebugger } from 'elm-ts/lib/Debug/Html'
 import * as React from 'elm-ts/lib/React'
 import { render } from 'react-dom'
 import * as component from './examples/Counter'

--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ const main = program(component.init, component.update, component.view)
 React.run(main, dom => render(dom, document.getElementById('app')!))
 ```
 
+For `Navigation` (and its specializations) programs:
+
+```ts
+import { programWithDebuggerWithFlags } from 'elm-ts/lib/Debug/Navigation'
+import * as Navigation from 'elm-ts/lib/Navigation'
+import * as React from 'elm-ts/lib/React'
+import { render } from 'react-dom'
+import * as component from './examples/Navigation'
+
+const program = process.env.NODE_ENV === 'production' ? Navigation.programWithFlags : programWithDebuggerWithFlags
+
+const main = program(component.locationToMsg, component.init, component.update, component.view)
+
+React.run(main(component.flags), dom => render(dom, document.getElementById('app')!))
+```
+
 ## Examples
 
 - [Counter](examples/Counter.tsx)

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,8 +49,10 @@ function fromCodec<A>(codec: t.Decoder<unknown, A>): Decoder<A> {
 
 ## Enable debugger in development mode
 
+For `Html` (and its specializations) programs:
+
 ```ts
-import { programWithDebugger } from 'elm-ts/lib/Debug'
+import { programWithDebugger } from 'elm-ts/lib/Debug/Html'
 import * as React from 'elm-ts/lib/React'
 import { render } from 'react-dom'
 import * as component from './examples/Counter'

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,22 @@ const main = program(component.init, component.update, component.view)
 React.run(main, dom => render(dom, document.getElementById('app')!))
 ```
 
+For `Navigation` (and its specializations) programs:
+
+```ts
+import { programWithDebuggerWithFlags } from 'elm-ts/lib/Debug/Navigation'
+import * as Navigation from 'elm-ts/lib/Navigation'
+import * as React from 'elm-ts/lib/React'
+import { render } from 'react-dom'
+import * as component from './examples/Navigation'
+
+const program = process.env.NODE_ENV === 'production' ? Navigation.programWithFlags : programWithDebuggerWithFlags
+
+const main = program(component.locationToMsg, component.init, component.update, component.view)
+
+React.run(main(component.flags), dom => render(dom, document.getElementById('app')!))
+```
+
 ## Examples
 
 - [Counter](examples/Counter.tsx)

--- a/docs/modules/Cmd.ts.md
+++ b/docs/modules/Cmd.ts.md
@@ -4,11 +4,13 @@ nav_order: 1
 parent: Modules
 ---
 
-# Overview
+# Cmd overview
 
 Defines `Cmd`s as streams of asynchronous operations which can not fail and that can optionally carry a message.
 
 See the [Platform.Cmd](https://package.elm-lang.org/packages/elm/core/latest/Platform-Cmd) Elm package.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Debug/Html.ts.md
+++ b/docs/modules/Debug/Html.ts.md
@@ -1,0 +1,97 @@
+---
+title: Debug/Html.ts
+nav_order: 4
+parent: Modules
+---
+
+# Overview
+
+This module makes available a debugging utility for `elm-ts` applications running `Html` programs.
+
+`elm-ts` ships with a [Redux DevTool Extension](https://github.com/zalmoxisus/redux-devtools-extension) integration, falling back to a simple debugger via standard browser's [`console`](https://developer.mozilla.org/en-US/docs/Web/API/Console) in case the extension is not available.
+
+**Note:** debugging is to be considered unsafe by design so it should be used only in **development**.
+
+This is an example of usage:
+
+```ts
+import { react, cmd } from 'elm-ts'
+import { programWithDebugger } from 'elm-ts/lib/Debug/Html'
+import { render } from 'react-dom'
+
+type Model = number
+type Msg = 'INCREMENT' | 'DECREMENT'
+
+declare const init: [Model, cmd.none]
+declare function update(msg: Msg, model: Model): [Model, cmd.Cmd<Msg>]
+declare function view(model: Model): react.Html<Msg>
+
+const program = process.NODE_ENV === 'production' ? react.program : programWithDebugger
+
+const main = program(init, update, view)
+
+react.run(main, dom => render(document.getElementById('app')))
+```
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [programWithDebugger (function)](#programwithdebugger-function)
+- [programWithDebuggerWithFlags (function)](#programwithdebuggerwithflags-function)
+
+---
+
+# programWithDebugger (function)
+
+Adds a debugging capability to a generic `Html` `Program`.
+
+It tracks every `Message` dispatched and resulting `Model` update.
+
+It also lets directly updating the application's state with a special `Message` of type:
+
+```ts
+{
+  type: '__DebugUpdateModel__'
+  payload: Model
+}
+```
+
+or applying a message with:
+
+```ts
+{
+  type: '__DebugApplyMsg__'
+  payload: Msg
+}
+```
+
+**Signature**
+
+```ts
+export function programWithDebugger<Model, Msg, Dom>(
+  init: [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
+  view: (model: Model) => Html<Dom, Msg>,
+  subscriptions?: (model: Model) => Sub<Msg>
+): Program<Model, Msg, Dom> { ... }
+```
+
+Added in v0.5.0
+
+# programWithDebuggerWithFlags (function)
+
+Same as `programWithDebugger()` but with `Flags` that can be passed when the `Program` is created in order to manage initial values.
+
+**Signature**
+
+```ts
+export function programWithDebuggerWithFlags<Flags, Model, Msg, Dom>(
+  init: (flags: Flags) => [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
+  view: (model: Model) => Html<Dom, Msg>,
+  subscriptions?: (model: Model) => Sub<Msg>
+): (flags: Flags) => Program<Model, Msg, Dom> { ... }
+```
+
+Added in v0.5.0

--- a/docs/modules/Debug/Html.ts.md
+++ b/docs/modules/Debug/Html.ts.md
@@ -4,7 +4,7 @@ nav_order: 4
 parent: Modules
 ---
 
-# Overview
+# Html overview
 
 This module makes available a debugging utility for `elm-ts` applications running `Html` programs.
 
@@ -32,6 +32,8 @@ const main = program(init, update, view)
 
 react.run(main, dom => render(document.getElementById('app')))
 ```
+
+Added in v0.5.3
 
 ---
 

--- a/docs/modules/Debug/Navigation.ts.md
+++ b/docs/modules/Debug/Navigation.ts.md
@@ -1,0 +1,101 @@
+---
+title: Debug/Navigation.ts
+nav_order: 6
+parent: Modules
+---
+
+# Overview
+
+This module makes available a debugging utility for `elm-ts` applications running `Navigation` programs.
+
+`elm-ts` ships with a [Redux DevTool Extension](https://github.com/zalmoxisus/redux-devtools-extension) integration, falling back to a simple debugger via standard browser's [`console`](https://developer.mozilla.org/en-US/docs/Web/API/Console) in case the extension is not available.
+
+**Note:** debugging is to be considered unsafe by design so it should be used only in **development**.
+
+This is an example of usage:
+
+```ts
+import { react, cmd } from 'elm-ts'
+import { programWithDebugger } from 'elm-ts/lib/Debug/Navigation'
+import { Location, program } from 'elm-ts/lib/Navigation'
+import { render } from 'react-dom'
+
+type Model = number
+type Msg = 'INCREMENT' | 'DECREMENT'
+
+declare function locationToMsg(location: Location): Msg
+declare function init(location: Location): [Model, cmd.none]
+declare function update(msg: Msg, model: Model): [Model, cmd.Cmd<Msg>]
+declare function view(model: Model): react.Html<Msg>
+
+const program = process.NODE_ENV === 'production' ? program : programWithDebugger
+
+const main = program(locationToMsg, init, update, view)
+
+react.run(main, dom => render(document.getElementById('app')))
+```
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [programWithDebugger (function)](#programwithdebugger-function)
+- [programWithDebuggerWithFlags (function)](#programwithdebuggerwithflags-function)
+
+---
+
+# programWithDebugger (function)
+
+Adds a debugging capability to a generic `Navigation` `Program`.
+
+It tracks every `Message` dispatched and resulting `Model` update.
+
+It also lets directly updating the application's state with a special `Message` of type:
+
+```ts
+{
+  type: '__DebugUpdateModel__'
+  payload: Model
+}
+```
+
+or applying a message with:
+
+```ts
+{
+  type: '__DebugApplyMsg__'
+  payload: Msg
+}
+```
+
+**Signature**
+
+```ts
+export function programWithDebugger<Model, Msg, Dom>(
+  locationToMessage: (location: Location) => Msg,
+  init: (location: Location) => [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
+  view: (model: Model) => Html<Dom, Msg>,
+  subscriptions?: (model: Model) => Sub<Msg>
+): Program<Model, Msg, Dom> { ... }
+```
+
+Added in v0.5.3
+
+# programWithDebuggerWithFlags (function)
+
+Same as `programWithDebugger()` but with `Flags` that can be passed when the `Program` is created in order to manage initial values.
+
+**Signature**
+
+```ts
+export function programWithDebuggerWithFlags<Flags, Model, Msg, Dom>(
+  locationToMessage: (location: Location) => Msg,
+  init: (flags: Flags) => (location: Location) => [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
+  view: (model: Model) => Html<Dom, Msg>,
+  subscriptions?: (model: Model) => Sub<Msg>
+): (flags: Flags) => Program<Model, Msg, Dom> { ... }
+```
+
+Added in v0.5.3

--- a/docs/modules/Debug/Navigation.ts.md
+++ b/docs/modules/Debug/Navigation.ts.md
@@ -4,7 +4,7 @@ nav_order: 6
 parent: Modules
 ---
 
-# Overview
+# Navigation overview
 
 This module makes available a debugging utility for `elm-ts` applications running `Navigation` programs.
 
@@ -34,6 +34,8 @@ const main = program(locationToMsg, init, update, view)
 
 react.run(main, dom => render(document.getElementById('app')))
 ```
+
+Added in v0.5.3
 
 ---
 

--- a/docs/modules/Debug/commons.ts.md
+++ b/docs/modules/Debug/commons.ts.md
@@ -4,6 +4,10 @@ nav_order: 2
 parent: Modules
 ---
 
+# Overview
+
+Common utilities and type definitions for the `Debug` module.
+
 ---
 
 <h2 class="text-delta">Table of contents</h2>
@@ -19,6 +23,8 @@ parent: Modules
 - [MsgWithDebug (type alias)](#msgwithdebug-type-alias)
 - [debugInit (function)](#debuginit-function)
 - [debugMsg (function)](#debugmsg-function)
+- [runDebugger (function)](#rundebugger-function)
+- [updateWithDebug (function)](#updatewithdebug-function)
 
 ---
 
@@ -84,7 +90,7 @@ Defines the dependencies for a `Debugger` function.
 ```ts
 export interface DebuggerR<Model, Msg> {
   init: Model
-  data$: BehaviorSubject<DebugData<Model, Msg>>
+  debug$: BehaviorSubject<DebugData<Model, Msg>>
   dispatch: Dispatch<MsgWithDebug<Model, Msg>>
 }
 ```
@@ -159,3 +165,50 @@ export const debugMsg = <Msg>(payload: Msg): DebugMsg<Msg> => ...
 ```
 
 Added in v0.5.0
+
+# runDebugger (function)
+
+Checks which type of debugger can be used (standard `console` or _Redux DevTool Extension_) based on provided `window` and prepares the subscription to the "debug" stream
+
+**Signature**
+
+```ts
+export function runDebugger<Model, Msg>(win: Global): (deps: DebuggerR<Model, Msg>) => IO<void> { ... }
+```
+
+Added in v0.5.3
+
+# updateWithDebug (function)
+
+Adds debugging capability to the provided `update` function.
+
+It tracks through the `debug$` stream every `Message` dispatched and resulting `Model` update.
+
+It also lets directly updating the application's state with a special `Message` of type:
+
+```ts
+{
+  type: '__DebugUpdateModel__'
+  payload: Model
+}
+```
+
+or applying a message with:
+
+```ts
+{
+  type: '__DebugApplyMsg__'
+  payload: Msg
+}
+```
+
+**Signature**
+
+```ts
+export function updateWithDebug<Model, Msg>(
+  debug$: BehaviorSubject<DebugData<Model, Msg>>,
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>]
+): (msg: MsgWithDebug<Model, Msg>, model: Model) => [Model, Cmd<Msg>] { ... }
+```
+
+Added in v0.5.3

--- a/docs/modules/Debug/commons.ts.md
+++ b/docs/modules/Debug/commons.ts.md
@@ -4,9 +4,11 @@ nav_order: 2
 parent: Modules
 ---
 
-# Overview
+# commons overview
 
 Common utilities and type definitions for the `Debug` module.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Debug/console.ts.md
+++ b/docs/modules/Debug/console.ts.md
@@ -4,9 +4,11 @@ nav_order: 3
 parent: Modules
 ---
 
-# Overview
+# console overview
 
-Debug via standard browser's `console`
+Debug via standard browser's `console`.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Debug/index.ts.md
+++ b/docs/modules/Debug/index.ts.md
@@ -4,13 +4,15 @@ nav_order: 5
 parent: Modules
 ---
 
-# Overview
+# index overview
 
 This module makes available a debugging utility for `elm-ts` applications.
 
 Use of the functions directly exported from this module is **deprecated**.
 
-Please use the specialized versions that you can find under `Debug/`
+Please use the specialized versions that you can find under `Debug/`.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Debug/index.ts.md
+++ b/docs/modules/Debug/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Debug/index.ts
-nav_order: 4
+nav_order: 5
 parent: Modules
 ---
 
@@ -8,90 +8,35 @@ parent: Modules
 
 This module makes available a debugging utility for `elm-ts` applications.
 
-`elm-ts` ships with a [Redux DevTool Extension](https://github.com/zalmoxisus/redux-devtools-extension) integration, falling back to a simple debugger via standard browser's [`console`](https://developer.mozilla.org/en-US/docs/Web/API/Console) in case the extension is not available.
+Use of the functions directly exported from this module is **deprecated**.
 
-**Note:** debugging is to be considered unsafe by design so it should be used only in **development**.
-
-This is an example of usage:
-
-```ts
-import { react, cmd } from 'elm-ts'
-import { programWithDebugger } from 'elm-ts/lib/Debug'
-import { render } from 'react-dom'
-
-type Model = number
-type Msg = 'INCREMENT' | 'DECREMENT'
-
-declare const init: [Model, cmd.none]
-declare function update(msg: Msg, model: Model): [Model, cmd.Cmd<Msg>]
-declare function view(model: Model): react.Html<Msg>
-
-const program = process.NODE_ENV === 'production' ? react.program : programWithDebugger
-
-const main = program(init, update, view)
-
-react.run(main, dom => render(document.getElementById('app')))
-```
+Please use the specialized versions that you can find under `Debug/`
 
 ---
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [programWithDebugger (function)](#programwithdebugger-function)
-- [programWithDebuggerWithFlags (function)](#programwithdebuggerwithflags-function)
+- [~~programWithDebugger~~ (constant)](#programwithdebugger-constant)
+- [~~programWithDebuggerWithFlags~~ (constant)](#programwithdebuggerwithflags-constant)
 
 ---
 
-# programWithDebugger (function)
-
-Adds a debugging capability to a generic `Html` `Program`.
-
-It tracks every `Message` dispatched and resulting `Model` update.
-
-It also lets directly updating the application's state with a special `Message` of type:
-
-```ts
-{
-  type: '__DebugUpdateModel__'
-  payload: Model
-}
-```
-
-or applying a message with:
-
-```ts
-{
-  type: '__DebugApplyMsg__'
-  payload: Msg
-}
-```
+# ~~programWithDebugger~~ (constant)
 
 **Signature**
 
 ```ts
-export function programWithDebugger<Model, Msg, Dom>(
-  init: [Model, Cmd<Msg>],
-  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
-  view: (model: Model) => Html<Dom, Msg>,
-  subscriptions?: (model: Model) => Sub<Msg>
-): Program<Model, Msg, Dom> { ... }
+export const programWithDebugger: typeof HtmlDebugger.programWithDebugger = ...
 ```
 
 Added in v0.5.0
 
-# programWithDebuggerWithFlags (function)
-
-Same as `programWithDebugger()` but with `Flags` that can be passed when the `Program` is created in order to manage initial values.
+# ~~programWithDebuggerWithFlags~~ (constant)
 
 **Signature**
 
 ```ts
-export function programWithDebuggerWithFlags<Flags, Model, Msg, Dom>(
-  init: (flags: Flags) => [Model, Cmd<Msg>],
-  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
-  view: (model: Model) => Html<Dom, Msg>,
-  subscriptions?: (model: Model) => Sub<Msg>
-): (flags: Flags) => Program<Model, Msg, Dom> { ... }
+export const programWithDebuggerWithFlags: typeof HtmlDebugger.programWithDebuggerWithFlags = ...
 ```
 
 Added in v0.5.0

--- a/docs/modules/Debug/redux-devtool.ts.md
+++ b/docs/modules/Debug/redux-devtool.ts.md
@@ -4,11 +4,13 @@ nav_order: 7
 parent: Modules
 ---
 
-# Overview
+# redux-devtool overview
 
 Integration with _Redux DevTool Extension_.
 
 Please check the [docs](https://github.com/zalmoxisus/redux-devtools-extension/tree/master/docs/API) fur further information.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Debug/redux-devtool.ts.md
+++ b/docs/modules/Debug/redux-devtool.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Debug/redux-devtool.ts
-nav_order: 5
+nav_order: 6
 parent: Modules
 ---
 

--- a/docs/modules/Debug/redux-devtool.ts.md
+++ b/docs/modules/Debug/redux-devtool.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Debug/redux-devtool.ts
-nav_order: 6
+nav_order: 7
 parent: Modules
 ---
 

--- a/docs/modules/Decode.ts.md
+++ b/docs/modules/Decode.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Decode.ts
-nav_order: 6
+nav_order: 7
 parent: Modules
 ---
 

--- a/docs/modules/Decode.ts.md
+++ b/docs/modules/Decode.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Decode.ts
-nav_order: 7
+nav_order: 8
 parent: Modules
 ---
 

--- a/docs/modules/Decode.ts.md
+++ b/docs/modules/Decode.ts.md
@@ -4,11 +4,13 @@ nav_order: 8
 parent: Modules
 ---
 
-# Overview
+# Decode overview
 
 Defines a `Decoder`, namely a function that receives an `unknown` value and tries to decodes it in an `A` value.
 
 It returns an `Either` with a `string` as `Left` when decoding fails or an `A` as `Right` when decoding succeeds.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Html.ts.md
+++ b/docs/modules/Html.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Html.ts
-nav_order: 7
+nav_order: 8
 parent: Modules
 ---
 

--- a/docs/modules/Html.ts.md
+++ b/docs/modules/Html.ts.md
@@ -4,12 +4,14 @@ nav_order: 9
 parent: Modules
 ---
 
-# Overview
+# Html overview
 
 A specialization of `Program` with the capability of mapping `Model` to `View`
 and rendering it into a DOM node.
 
 `Html` is a base abstraction in order to work with any library that renders html.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Html.ts.md
+++ b/docs/modules/Html.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Html.ts
-nav_order: 8
+nav_order: 9
 parent: Modules
 ---
 

--- a/docs/modules/Http.ts.md
+++ b/docs/modules/Http.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Http.ts
-nav_order: 8
+nav_order: 9
 parent: Modules
 ---
 

--- a/docs/modules/Http.ts.md
+++ b/docs/modules/Http.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Http.ts
-nav_order: 9
+nav_order: 10
 parent: Modules
 ---
 

--- a/docs/modules/Http.ts.md
+++ b/docs/modules/Http.ts.md
@@ -4,11 +4,13 @@ nav_order: 10
 parent: Modules
 ---
 
-# Overview
+# Http overview
 
 Makes http calls to remote resources as `Cmd`s.
 
 See [Http](https://package.elm-lang.org/packages/elm/http/latest/Http) Elm package.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Navigation.ts.md
+++ b/docs/modules/Navigation.ts.md
@@ -4,11 +4,13 @@ nav_order: 12
 parent: Modules
 ---
 
-# Overview
+# Navigation overview
 
 A specialization of `Program` that handles application navigation via location's hash.
 
-It uses [`history`](https://github.com/ReactTraining/history) package
+It uses [`history`](https://github.com/ReactTraining/history) package.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Navigation.ts.md
+++ b/docs/modules/Navigation.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Navigation.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/Navigation.ts.md
+++ b/docs/modules/Navigation.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Navigation.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/docs/modules/Platform.ts.md
+++ b/docs/modules/Platform.ts.md
@@ -4,11 +4,13 @@ nav_order: 13
 parent: Modules
 ---
 
-# Overview
+# Platform overview
 
 The `Platform` module is the backbone of `elm-ts`.
 It defines the base `program()` and `run()` functions which will be extended by more specialized modules.
 _The Elm Architecture_ is implemented via **RxJS** `Observables`.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Platform.ts.md
+++ b/docs/modules/Platform.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Platform.ts
-nav_order: 11
+nav_order: 12
 parent: Modules
 ---
 

--- a/docs/modules/Platform.ts.md
+++ b/docs/modules/Platform.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Platform.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/React.ts.md
+++ b/docs/modules/React.ts.md
@@ -4,9 +4,11 @@ nav_order: 14
 parent: Modules
 ---
 
-# Overview
+# React overview
 
 A specialization of `Html` that uses `React` as renderer.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/React.ts.md
+++ b/docs/modules/React.ts.md
@@ -1,6 +1,6 @@
 ---
 title: React.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/React.ts.md
+++ b/docs/modules/React.ts.md
@@ -1,6 +1,6 @@
 ---
 title: React.ts
-nav_order: 12
+nav_order: 13
 parent: Modules
 ---
 

--- a/docs/modules/Sub.ts.md
+++ b/docs/modules/Sub.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Sub.ts
-nav_order: 13
+nav_order: 14
 parent: Modules
 ---
 

--- a/docs/modules/Sub.ts.md
+++ b/docs/modules/Sub.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Sub.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/Sub.ts.md
+++ b/docs/modules/Sub.ts.md
@@ -4,9 +4,11 @@ nav_order: 15
 parent: Modules
 ---
 
-# Overview
+# Sub overview
 
 Defines `Sub`s as streams of messages.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -4,11 +4,13 @@ nav_order: 16
 parent: Modules
 ---
 
-# Overview
+# Task overview
 
 Handles the execution of asynchronous effectful operations.
 
 See the [Task](https://package.elm-lang.org/packages/elm/core/latest/Task) Elm package.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task.ts
-nav_order: 14
+nav_order: 15
 parent: Modules
 ---
 

--- a/docs/modules/Time.ts.md
+++ b/docs/modules/Time.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Time.ts
-nav_order: 15
+nav_order: 16
 parent: Modules
 ---
 

--- a/docs/modules/Time.ts.md
+++ b/docs/modules/Time.ts.md
@@ -4,10 +4,13 @@ nav_order: 17
 parent: Modules
 ---
 
-# Overview
+# Time overview
 
 Exposes some utilities to work with unix time.
+
 See [Time](https://package.elm-lang.org/packages/elm/time/latest/Time) Elm package.
+
+Added in v0.5.0
 
 ---
 

--- a/docs/modules/Time.ts.md
+++ b/docs/modules/Time.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Time.ts
-nav_order: 16
+nav_order: 17
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 9
+nav_order: 10
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -4,6 +4,10 @@ nav_order: 11
 parent: Modules
 ---
 
+# index overview
+
+Added in v0.5.0
+
 ---
 
 <h2 class="text-delta">Table of contents</h2>

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 10
+nav_order: 11
 parent: Modules
 ---
 

--- a/examples/DebuggerHtml.tsx
+++ b/examples/DebuggerHtml.tsx
@@ -1,5 +1,5 @@
 import { render } from 'react-dom'
-import { programWithDebugger } from '../src/Debug'
+import { programWithDebugger } from '../src/Debug/Html'
 import * as React from '../src/React'
 import * as component from './Counter'
 

--- a/examples/Navigation.tsx
+++ b/examples/Navigation.tsx
@@ -30,12 +30,12 @@ function getRoute(location: Location): Route {
   return isRoute(route) ? route : defaultRoute
 }
 
-export function locationToMessage(location: Location): Msg {
+export function locationToMsg(location: Location): Msg {
   return { type: getRoute(location) } as Msg
 }
 
-export function init(_: Flags, location: Location): [Model, cmd.Cmd<Msg>] {
-  return [getRoute(location), cmd.none]
+export function init(_: Flags): (location: Location) => [Model, cmd.Cmd<Msg>] {
+  return location => [getRoute(location), cmd.none]
 }
 
 // --- Messages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-ts",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,26 @@
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "js-tokens": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -290,6 +310,26 @@
         "slash": "^2.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -334,6 +374,26 @@
         "strip-ansi": "^5.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
@@ -400,6 +460,26 @@
         "string-length": "^2.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -486,6 +566,26 @@
         "write-file-atomic": "2.4.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
@@ -668,6 +768,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/events": {
       "version": "3.0.0",
@@ -1338,29 +1444,53 @@
       "dev": true
     },
     "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.1.0",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^4.0.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+          "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -3178,6 +3308,15 @@
         "jest-cli": "^24.9.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
         "jest-cli": {
           "version": "24.9.0",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
@@ -3197,6 +3336,19 @@
             "prompts": "^2.0.1",
             "realpath-native": "^1.1.0",
             "yargs": "^13.3.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
           }
         }
       }
@@ -3235,6 +3387,28 @@
         "micromatch": "^3.1.10",
         "pretty-format": "^24.9.0",
         "realpath-native": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -3247,6 +3421,28 @@
         "diff-sequences": "^24.9.0",
         "jest-get-type": "^24.9.0",
         "pretty-format": "^24.9.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-docblock": {
@@ -3269,6 +3465,28 @@
         "jest-get-type": "^24.9.0",
         "jest-util": "^24.9.0",
         "pretty-format": "^24.9.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-environment-jsdom": {
@@ -3984,6 +4202,28 @@
         "jest-util": "^24.9.0",
         "pretty-format": "^24.9.0",
         "throat": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-leak-detector": {
@@ -4006,6 +4246,28 @@
         "jest-diff": "^24.9.0",
         "jest-get-type": "^24.9.0",
         "pretty-format": "^24.9.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-message-util": {
@@ -4024,6 +4286,26 @@
         "stack-utils": "^1.0.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -4064,6 +4346,28 @@
         "chalk": "^2.0.1",
         "jest-pnp-resolver": "^1.2.1",
         "realpath-native": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-resolve-dependencies": {
@@ -4179,6 +4483,26 @@
         "yargs": "^13.3.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "glob": {
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -4234,6 +4558,26 @@
         "semver": "^6.2.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -4262,6 +4606,26 @@
         "source-map": "^0.6.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
@@ -4294,6 +4658,28 @@
         "jest-get-type": "^24.9.0",
         "leven": "^3.1.0",
         "pretty-format": "^24.9.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-watcher": {
@@ -4309,6 +4695,28 @@
         "chalk": "^2.0.1",
         "jest-util": "^24.9.0",
         "string-length": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-worker": {
@@ -6634,6 +7042,28 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "tslint-config-standard": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -579,6 +579,46 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@ts-morph/common": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.1.1.tgz",
+      "integrity": "sha512-8TLlC85CXgKNoTeqoXtrscPmKDbQCBfwZJ4hqli/QI4STa7sD2H6UqI9LSg8uBV5FYaD0QSdj/mtrCDrELvF+Q==",
+      "dev": true,
+      "requires": {
+        "@dsherret/to-absolute-glob": "^2.0.2",
+        "fs-extra": "^8.1.0",
+        "glob-parent": "^5.1.0",
+        "globby": "^10.0.1",
+        "is-negated-glob": "^1.0.0",
+        "multimatch": "^4.0.0",
+        "typescript": "~3.7.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+          "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+          "dev": true
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -699,9 +739,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.55.tgz",
-      "integrity": "sha512-iZeh1EgupfmAAOASk580R1SL5lWF3CsBVgVH0395qyNF8fhO16xy1UwAav2PdGxIIsYRn7RzJgMGjdsvam6YYg==",
+      "version": "10.17.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.9.tgz",
+      "integrity": "sha512-+6VygF9LbG7Gaqeog2G7u1+RUcmo0q1rI+2ZxdIg2fAUngk5Vz9fOCHXdloNUOHEPd1EuuOpL5O0CdgN9Fx5UQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1372,9 +1412,9 @@
       "dev": true
     },
     "code-block-writer": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-9.4.1.tgz",
-      "integrity": "sha512-LHAB+DL4YZDcwK8y/kAxZ0Lf/ncwLh/Ux4cTVWbPwIdrf1gPxXiPcwpz8r8/KqXu1aD+Raz46EOxDjFlbyO6bA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.0.tgz",
+      "integrity": "sha512-RG9hpXtWFeUWhuUav1YuP/vGcyncW+t90yJLk9fNZs1De2OuHTHKAKThVCokt29PYq5RoJ0QSZaIZ+rvPO23hA==",
       "dev": true
     },
     "coffee-script": {
@@ -1672,9 +1712,9 @@
       }
     },
     "docs-ts": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/docs-ts/-/docs-ts-0.2.1.tgz",
-      "integrity": "sha512-ewBCcx9t3VIKHTfN0e3CjL46nLSQ0BvusMvzh0fGn9tf3rEh5l9MgrTv0yoU5G/XNGEoO7MY6sJ185sz9aDVEg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/docs-ts/-/docs-ts-0.3.0.tgz",
+      "integrity": "sha512-zDD2K7t5mRC5y8lgYXFht7QHUxVZUAp/WjG/3Q9sOfqn2xOS5XbxAWz4wuf2dH/hXjB4u0u22pQatHUtO7FQBQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -1683,9 +1723,8 @@
         "fs-extra": "^7.0.1",
         "glob": "^7.1.3",
         "markdown-toc": "^1.2.0",
-        "prettier": "^1.16.4",
         "rimraf": "^2.6.3",
-        "ts-morph": "^3.1.2",
+        "ts-morph": "^5.0.0",
         "ts-node": "^8.0.2"
       },
       "dependencies": {
@@ -1709,29 +1748,6 @@
             "supports-color": "^5.3.0"
           }
         },
-        "doctrine": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -1744,27 +1760,12 @@
       }
     },
     "doctrine": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
-      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
-        "esutils": "^1.1.6",
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "esutils": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
+        "esutils": "^2.0.2"
       }
     },
     "domexception": {
@@ -2140,9 +2141,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
-      "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
+      "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2399,22 +2400,6 @@
         "ignore": "^5.1.1",
         "merge2": "^1.2.3",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "graceful-fs": {
@@ -5224,9 +5209,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
+      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
       "dev": true
     },
     "pify": {
@@ -6593,38 +6578,14 @@
       }
     },
     "ts-morph": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-3.1.3.tgz",
-      "integrity": "sha512-CwjgyJTtd3f8vBi7Vr0IOgdOY6Wi/Tq0MhieXOE2B5ns5WWRD7BwMNHtv+ZufKI/S2U/lMrh+Q3bOauE4tsv2g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-5.0.0.tgz",
+      "integrity": "sha512-VP5dFnOzmlsDkSyuGczgVNtyJdYXMxFqMO2Rb0pIeni0o0Cy/nDljETBWhJs4FI4DIWv7Ftq69kgZO8p8w6LCw==",
       "dev": true,
       "requires": {
         "@dsherret/to-absolute-glob": "^2.0.2",
-        "code-block-writer": "9.4.1",
-        "fs-extra": "^8.1.0",
-        "glob-parent": "^5.0.0",
-        "globby": "^10.0.1",
-        "is-negated-glob": "^1.0.0",
-        "multimatch": "^4.0.0",
-        "typescript": "^3.0.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-          "dev": true
-        }
+        "@ts-morph/common": "~0.1.0",
+        "code-block-writer": "^10.0.0"
       }
     },
     "ts-node": {
@@ -6676,9 +6637,9 @@
       }
     },
     "tslint-config-standard": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-8.0.1.tgz",
-      "integrity": "sha512-OWG+NblgjQlVuUS/Dmq3ax2v5QDZwRx4L0kEuDi7qFY9UI6RJhhNfoCV1qI4el8Fw1c5a5BTrjQJP0/jhGXY/Q==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-9.0.0.tgz",
+      "integrity": "sha512-CAw9J743RnPMemQV/XQ4YyNreC+A1NItACfkm+cBedrOkz6CQfwlnbKn8anUXBfoa4Zo4tjAhblRbsMNcSLfSw==",
       "dev": true,
       "requires": {
         "tslint-eslint-rules": "^5.3.1"
@@ -6695,6 +6656,28 @@
         "tsutils": "^3.0.0"
       },
       "dependencies": {
+        "doctrine": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+          "dev": true,
+          "requires": {
+            "esutils": "^1.1.6",
+            "isarray": "0.0.1"
+          }
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
         "tslib": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
@@ -6702,9 +6685,9 @@
           "dev": true
         },
         "tsutils": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
-          "integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
           "dev": true,
           "requires": {
             "tslib": "^1.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-ts",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A porting of TEA to TypeScript featuring fp-ts, rxjs6 and React",
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/react-dom": "^16.9.3",
     "@types/sinon": "^7.5.0",
     "blessed": "^0.1.81",
+    "chalk": "^3.0.0",
     "docs-ts": "^0.3.0",
     "fp-ts": "^2.0.2",
     "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
     "@types/glob": "^7.1.1",
     "@types/history": "^4.6.2",
     "@types/jest": "^24.0.18",
-    "@types/node": "^8.10.54",
+    "@types/node": "^10.17.9",
     "@types/react": "^16.0.27",
     "@types/react-dom": "^16.9.3",
     "@types/sinon": "^7.5.0",
     "blessed": "^0.1.81",
-    "docs-ts": "^0.2.0",
+    "docs-ts": "^0.3.0",
     "fp-ts": "^2.0.2",
     "glob": "^7.1.6",
     "husky": "^3.0.8",
@@ -79,7 +79,7 @@
     "ts-jest": "^24.1.0",
     "ts-node": "^8.4.1",
     "tslint": "^5.18.0",
-    "tslint-config-standard": "^8.0.1",
+    "tslint-config-standard": "^9.0.0",
     "typescript": "^3.5.3"
   },
   "jest": {

--- a/scripts/helpers/logger.ts
+++ b/scripts/helpers/logger.ts
@@ -1,13 +1,16 @@
+import chalk from 'chalk'
 import { info, log } from 'fp-ts/lib/Console'
 import { rightIO } from 'fp-ts/lib/TaskEither'
 import { Eff } from './program'
 
 export interface Logger {
+  readonly debug: (s: string) => Eff<void>
   readonly info: (s: string) => Eff<void>
   readonly log: (s: string) => Eff<void>
 }
 
 export const loggerConsole: Logger = {
-  info: s => rightIO(info(`> ${s}`)),
-  log: s => rightIO(log(`\n> ${s}`))
+  debug: s => rightIO(log(chalk.gray(s))),
+  info: s => rightIO(info(chalk.bold.magenta(s))),
+  log: s => rightIO(log(chalk.bold.green(s)))
 }

--- a/scripts/helpers/program.ts
+++ b/scripts/helpers/program.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import { fold } from 'fp-ts/lib/Either'
 import * as RTE from 'fp-ts/lib/ReaderTaskEither'
 import * as TE from 'fp-ts/lib/TaskEither'
@@ -19,7 +20,7 @@ export function run<A>(eff: Eff<A>): void {
       )
     )
     .catch(e => {
-      console.error('[ERROR]', e)
+      console.error(chalk.red('[ERROR]', e))
 
       process.exitCode = 1
     })

--- a/scripts/rewrite-es6-paths.ts
+++ b/scripts/rewrite-es6-paths.ts
@@ -21,7 +21,7 @@ const replacePath = (content: string): string => content.replace(PATH_REGEXP, '$
 
 const rewritePaths = (file: string): AppEff<void> => C =>
   pipe(
-    C.info(`Rewriting file ${file}`),
+    C.debug(`Rewriting file ${file}`),
     TE.chain(() => C.readFile(file)),
     TE.map(replacePath),
     TE.chain(content => C.writeFile(file, content))

--- a/src/Cmd.ts
+++ b/src/Cmd.ts
@@ -1,7 +1,9 @@
 /**
- * @file Defines `Cmd`s as streams of asynchronous operations which can not fail and that can optionally carry a message.
+ * Defines `Cmd`s as streams of asynchronous operations which can not fail and that can optionally carry a message.
  *
  * See the [Platform.Cmd](https://package.elm-lang.org/packages/elm/core/latest/Platform-Cmd) Elm package.
+ *
+ * @since 0.5.0
  */
 
 import { Option, option, some } from 'fp-ts/lib/Option'

--- a/src/Debug/Html.ts
+++ b/src/Debug/Html.ts
@@ -1,0 +1,93 @@
+/**
+ * @file This module makes available a debugging utility for `elm-ts` applications running `Html` programs.
+ *
+ * `elm-ts` ships with a [Redux DevTool Extension](https://github.com/zalmoxisus/redux-devtools-extension) integration, falling back to a simple debugger via standard browser's [`console`](https://developer.mozilla.org/en-US/docs/Web/API/Console) in case the extension is not available.
+ *
+ * **Note:** debugging is to be considered unsafe by design so it should be used only in **development**.
+ *
+ * This is an example of usage:
+ * ```ts
+ * import {react, cmd} from 'elm-ts'
+ * import {programWithDebugger} from 'elm-ts/lib/Debug/Html'
+ * import { render } from 'react-dom'
+ *
+ * type Model = number
+ * type Msg = 'INCREMENT' | 'DECREMENT'
+ *
+ * declare const init: [Model, cmd.none]
+ * declare function update(msg: Msg, model: Model): [Model, cmd.Cmd<Msg>]
+ * declare function view(model: Model): react.Html<Msg>
+ *
+ * const program = process.NODE_ENV === 'production' ? react.program : programWithDebugger
+ *
+ * const main = program(init, update, view)
+ *
+ * react.run(main, dom => render(document.getElementById('app')))
+ * ```
+ *
+ * @since 0.5.3
+ */
+
+import { BehaviorSubject } from 'rxjs'
+import { Cmd } from '../Cmd'
+import { Html, Program, program } from '../Html'
+import { Sub } from '../Sub'
+import { DebugData, DebuggerR, debugInit, runDebugger, updateWithDebug } from './commons'
+
+/**
+ * Adds a debugging capability to a generic `Html` `Program`.
+ *
+ * It tracks every `Message` dispatched and resulting `Model` update.
+ *
+ * It also lets directly updating the application's state with a special `Message` of type:
+ *
+ * ```ts
+ * {
+ *   type: '__DebugUpdateModel__'
+ *   payload: Model
+ * }
+ * ```
+ *
+ * or applying a message with:
+ * ```ts
+ * {
+ *   type: '__DebugApplyMsg__';
+ *   payload: Msg
+ * }
+ * ```
+ * @since 0.5.0
+ */
+export function programWithDebugger<Model, Msg, Dom>(
+  init: [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
+  view: (model: Model) => Html<Dom, Msg>,
+  subscriptions?: (model: Model) => Sub<Msg>
+): Program<Model, Msg, Dom> {
+  const Debugger = runDebugger<Model, Msg>(window)
+
+  const initModel = init[0]
+
+  const debug$ = new BehaviorSubject<DebugData<Model, Msg>>([debugInit(), initModel])
+
+  const p = program(init, updateWithDebug(debug$, update), view, subscriptions)
+
+  // --- Run the debugger
+  // --- we need to make a type assertion for `dispatch` because we cannot change the intrinsic `msg` type of `program`;
+  // --- otherwise `programWithDebugger` won't be usable as a transparent extension/substitution of `Html`'s programs
+  Debugger({ debug$: debug$, init: initModel, dispatch: p.dispatch as DebuggerR<Model, Msg>['dispatch'] })()
+
+  return p
+}
+
+/**
+ * Same as `programWithDebugger()` but with `Flags` that can be passed when the `Program` is created in order to manage initial values.
+ * @since 0.5.0
+ */
+export function programWithDebuggerWithFlags<Flags, Model, Msg, Dom>(
+  init: (flags: Flags) => [Model, Cmd<Msg>],
+  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
+  view: (model: Model) => Html<Dom, Msg>,
+  subscriptions?: (model: Model) => Sub<Msg>
+): (flags: Flags) => Program<Model, Msg, Dom> {
+  return flags => programWithDebugger(init(flags), update, view, subscriptions)
+}

--- a/src/Debug/Html.ts
+++ b/src/Debug/Html.ts
@@ -1,5 +1,5 @@
 /**
- * @file This module makes available a debugging utility for `elm-ts` applications running `Html` programs.
+ * This module makes available a debugging utility for `elm-ts` applications running `Html` programs.
  *
  * `elm-ts` ships with a [Redux DevTool Extension](https://github.com/zalmoxisus/redux-devtools-extension) integration, falling back to a simple debugger via standard browser's [`console`](https://developer.mozilla.org/en-US/docs/Web/API/Console) in case the extension is not available.
  *

--- a/src/Debug/Navigation.ts
+++ b/src/Debug/Navigation.ts
@@ -1,5 +1,5 @@
 /**
- * @file This module makes available a debugging utility for `elm-ts` applications running `Html` programs.
+ * @file This module makes available a debugging utility for `elm-ts` applications running `Navigation` programs.
  *
  * `elm-ts` ships with a [Redux DevTool Extension](https://github.com/zalmoxisus/redux-devtools-extension) integration, falling back to a simple debugger via standard browser's [`console`](https://developer.mozilla.org/en-US/docs/Web/API/Console) in case the extension is not available.
  *
@@ -8,19 +8,21 @@
  * This is an example of usage:
  * ```ts
  * import {react, cmd} from 'elm-ts'
- * import {programWithDebugger} from 'elm-ts/lib/Debug/Html'
- * import { render } from 'react-dom'
+ * import {programWithDebugger} from 'elm-ts/lib/Debug/Navigation'
+ * import {Location, program} from 'elm-ts/lib/Navigation'
+ * import {render} from 'react-dom'
  *
  * type Model = number
  * type Msg = 'INCREMENT' | 'DECREMENT'
  *
- * declare const init: [Model, cmd.none]
+ * declare function locationToMsg(location: Location): Msg
+ * declare function init(location: Location): [Model, cmd.none]
  * declare function update(msg: Msg, model: Model): [Model, cmd.Cmd<Msg>]
  * declare function view(model: Model): react.Html<Msg>
  *
- * const program = process.NODE_ENV === 'production' ? react.program : programWithDebugger
+ * const program = process.NODE_ENV === 'production' ? program : programWithDebugger
  *
- * const main = program(init, update, view)
+ * const main = program(locationToMsg, init, update, view)
  *
  * react.run(main, dom => render(document.getElementById('app')))
  * ```
@@ -28,14 +30,16 @@
  * @since 0.5.3
  */
 
+import * as H from 'history'
 import { BehaviorSubject } from 'rxjs'
 import { Cmd } from '../Cmd'
-import { Html, Program, program } from '../Html'
+import { Html, Program } from '../Html'
+import { Location, program } from '../Navigation'
 import { Sub } from '../Sub'
 import { DebugData, DebuggerR, debugInit, runDebugger, updateWithDebug } from './commons'
 
 /**
- * Adds a debugging capability to a generic `Html` `Program`.
+ * Adds a debugging capability to a generic `Navigation` `Program`.
  *
  * It tracks every `Message` dispatched and resulting `Model` update.
  *
@@ -55,21 +59,24 @@ import { DebugData, DebuggerR, debugInit, runDebugger, updateWithDebug } from '.
  *   payload: Msg
  * }
  * ```
- * @since 0.5.0
+ * @since 0.5.3
  */
 export function programWithDebugger<Model, Msg, Dom>(
-  init: [Model, Cmd<Msg>],
+  locationToMessage: (location: Location) => Msg,
+  init: (location: Location) => [Model, Cmd<Msg>],
   update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
   view: (model: Model) => Html<Dom, Msg>,
   subscriptions?: (model: Model) => Sub<Msg>
 ): Program<Model, Msg, Dom> {
+  const history = H.createHashHistory() // this is needed only to generate init model for debug$ :S
+
   const Debugger = runDebugger<Model, Msg>(window)
 
-  const initModel = init[0]
+  const initModel = init(history.location)[0]
 
   const debug$ = new BehaviorSubject<DebugData<Model, Msg>>([debugInit(), initModel])
 
-  const p = program(init, updateWithDebug(debug$, update), view, subscriptions)
+  const p = program(locationToMessage, init, updateWithDebug(debug$, update), view, subscriptions)
 
   // --- Run the debugger
   // --- we need to make a type assertion for `dispatch` because we cannot change the intrinsic `msg` type of `program`;
@@ -81,13 +88,14 @@ export function programWithDebugger<Model, Msg, Dom>(
 
 /**
  * Same as `programWithDebugger()` but with `Flags` that can be passed when the `Program` is created in order to manage initial values.
- * @since 0.5.0
+ * @since 0.5.3
  */
 export function programWithDebuggerWithFlags<Flags, Model, Msg, Dom>(
-  init: (flags: Flags) => [Model, Cmd<Msg>],
+  locationToMessage: (location: Location) => Msg,
+  init: (flags: Flags) => (location: Location) => [Model, Cmd<Msg>],
   update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
   view: (model: Model) => Html<Dom, Msg>,
   subscriptions?: (model: Model) => Sub<Msg>
 ): (flags: Flags) => Program<Model, Msg, Dom> {
-  return flags => programWithDebugger(init(flags), update, view, subscriptions)
+  return flags => programWithDebugger(locationToMessage, init(flags), update, view, subscriptions)
 }

--- a/src/Debug/Navigation.ts
+++ b/src/Debug/Navigation.ts
@@ -1,5 +1,5 @@
 /**
- * @file This module makes available a debugging utility for `elm-ts` applications running `Navigation` programs.
+ * This module makes available a debugging utility for `elm-ts` applications running `Navigation` programs.
  *
  * `elm-ts` ships with a [Redux DevTool Extension](https://github.com/zalmoxisus/redux-devtools-extension) integration, falling back to a simple debugger via standard browser's [`console`](https://developer.mozilla.org/en-US/docs/Web/API/Console) in case the extension is not available.
  *

--- a/src/Debug/commons.ts
+++ b/src/Debug/commons.ts
@@ -1,5 +1,5 @@
 /**
- * @file Common utilities and type definitions for the `Debug` module.
+ * Common utilities and type definitions for the `Debug` module.
  *
  * @since 0.5.0
  */

--- a/src/Debug/commons.ts
+++ b/src/Debug/commons.ts
@@ -1,3 +1,8 @@
+/**
+ * @file Common utilities and type definitions for the `Debug` module.
+ *
+ * @since 0.5.0
+ */
 import { IO, chain, map } from 'fp-ts/lib/IO'
 import { fold } from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'

--- a/src/Debug/console.ts
+++ b/src/Debug/console.ts
@@ -1,5 +1,7 @@
 /**
- * @file Debug via standard browser's `console`
+ * Debug via standard browser's `console`.
+ *
+ * @since 0.5.0
  */
 
 import { Option, alt, fromNullable, getOrElse } from 'fp-ts/lib/Option'

--- a/src/Debug/index.ts
+++ b/src/Debug/index.ts
@@ -1,9 +1,9 @@
 /**
- * @file This module makes available a debugging utility for `elm-ts` applications.
+ * This module makes available a debugging utility for `elm-ts` applications.
  *
  * Use of the functions directly exported from this module is **deprecated**.
  *
- * Please use the specialized versions that you can find under `Debug/`
+ * Please use the specialized versions that you can find under `Debug/`.
  *
  * @since 0.5.0
  */

--- a/src/Debug/index.ts
+++ b/src/Debug/index.ts
@@ -26,16 +26,11 @@
  * ```
  */
 
-// import { IO, chain, map } from 'fp-ts/lib/IO'
-// import { fold } from 'fp-ts/lib/Option'
-// import { pipe } from 'fp-ts/lib/pipeable'
 import { BehaviorSubject } from 'rxjs'
-import { Cmd, none } from '../Cmd'
+import { Cmd } from '../Cmd'
 import { Html, Program, program } from '../Html'
 import { Sub } from '../Sub'
-import { DebugData, DebuggerR, MsgWithDebug, debugInit, debugMsg, runDebugger } from './commons'
-// import { consoleDebugger } from './console'
-// import { getConnection, reduxDevToolDebugger } from './redux-devtool'
+import { DebugData, DebuggerR, debugInit, runDebugger, updateWithDebug } from './commons'
 
 /**
  * Adds a debugging capability to a generic `Html` `Program`.
@@ -72,25 +67,7 @@ export function programWithDebugger<Model, Msg, Dom>(
 
   const debug$ = new BehaviorSubject<DebugData<Model, Msg>>([debugInit(), initModel])
 
-  const updateWithDebug = (msg: MsgWithDebug<Model, Msg>, model: Model): [Model, Cmd<Msg>] => {
-    if ('type' in msg) {
-      switch (msg.type) {
-        case '__DebugUpdateModel__':
-          return [msg.payload, none]
-
-        case '__DebugApplyMsg__':
-          return [update(msg.payload, model)[0], none]
-      }
-    }
-
-    const result = update(msg, model)
-
-    debug$.next([debugMsg(msg), result[0]])
-
-    return result
-  }
-
-  const p = program(init, updateWithDebug, view, subscriptions)
+  const p = program(init, updateWithDebug(debug$, update), view, subscriptions)
 
   // --- Run the debugger
   // --- we need to make a type assertion for `dispatch` because we cannot change the intrinsic `msg` type of `program`;

--- a/src/Debug/index.ts
+++ b/src/Debug/index.ts
@@ -1,91 +1,23 @@
 /**
  * @file This module makes available a debugging utility for `elm-ts` applications.
  *
- * `elm-ts` ships with a [Redux DevTool Extension](https://github.com/zalmoxisus/redux-devtools-extension) integration, falling back to a simple debugger via standard browser's [`console`](https://developer.mozilla.org/en-US/docs/Web/API/Console) in case the extension is not available.
+ * Use of the functions directly exported from this module is **deprecated**.
  *
- * **Note:** debugging is to be considered unsafe by design so it should be used only in **development**.
+ * Please use the specialized versions that you can find under `Debug/`
  *
- * This is an example of usage:
- * ```ts
- * import {react, cmd} from 'elm-ts'
- * import {programWithDebugger} from 'elm-ts/lib/Debug'
- * import { render } from 'react-dom'
- *
- * type Model = number
- * type Msg = 'INCREMENT' | 'DECREMENT'
- *
- * declare const init: [Model, cmd.none]
- * declare function update(msg: Msg, model: Model): [Model, cmd.Cmd<Msg>]
- * declare function view(model: Model): react.Html<Msg>
- *
- * const program = process.NODE_ENV === 'production' ? react.program : programWithDebugger
- *
- * const main = program(init, update, view)
- *
- * react.run(main, dom => render(document.getElementById('app')))
- * ```
- */
-
-import { BehaviorSubject } from 'rxjs'
-import { Cmd } from '../Cmd'
-import { Html, Program, program } from '../Html'
-import { Sub } from '../Sub'
-import { DebugData, DebuggerR, debugInit, runDebugger, updateWithDebug } from './commons'
-
-/**
- * Adds a debugging capability to a generic `Html` `Program`.
- *
- * It tracks every `Message` dispatched and resulting `Model` update.
- *
- * It also lets directly updating the application's state with a special `Message` of type:
- *
- * ```ts
- * {
- *   type: '__DebugUpdateModel__'
- *   payload: Model
- * }
- * ```
- *
- * or applying a message with:
- * ```ts
- * {
- *   type: '__DebugApplyMsg__';
- *   payload: Msg
- * }
- * ```
  * @since 0.5.0
  */
-export function programWithDebugger<Model, Msg, Dom>(
-  init: [Model, Cmd<Msg>],
-  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
-  view: (model: Model) => Html<Dom, Msg>,
-  subscriptions?: (model: Model) => Sub<Msg>
-): Program<Model, Msg, Dom> {
-  const Debugger = runDebugger<Model, Msg>(window)
 
-  const initModel = init[0]
-
-  const debug$ = new BehaviorSubject<DebugData<Model, Msg>>([debugInit(), initModel])
-
-  const p = program(init, updateWithDebug(debug$, update), view, subscriptions)
-
-  // --- Run the debugger
-  // --- we need to make a type assertion for `dispatch` because we cannot change the intrinsic `msg` type of `program`;
-  // --- otherwise `programWithDebugger` won't be usable as a transparent extension/substitution of `Html`'s programs
-  Debugger({ debug$: debug$, init: initModel, dispatch: p.dispatch as DebuggerR<Model, Msg>['dispatch'] })()
-
-  return p
-}
+import * as HtmlDebugger from './Html'
 
 /**
- * Same as `programWithDebugger()` but with `Flags` that can be passed when the `Program` is created in order to manage initial values.
+ * @deprecated Please use the specialized version exposed by `Debug/Html` module
  * @since 0.5.0
  */
-export function programWithDebuggerWithFlags<Flags, Model, Msg, Dom>(
-  init: (flags: Flags) => [Model, Cmd<Msg>],
-  update: (msg: Msg, model: Model) => [Model, Cmd<Msg>],
-  view: (model: Model) => Html<Dom, Msg>,
-  subscriptions?: (model: Model) => Sub<Msg>
-): (flags: Flags) => Program<Model, Msg, Dom> {
-  return flags => programWithDebugger(init(flags), update, view, subscriptions)
-}
+export const programWithDebugger = HtmlDebugger.programWithDebugger
+
+/**
+ * @deprecated Please use the specialized version exposed by `Debug/Html` module
+ * @since 0.5.0
+ */
+export const programWithDebuggerWithFlags = HtmlDebugger.programWithDebuggerWithFlags

--- a/src/Debug/redux-devtool.ts
+++ b/src/Debug/redux-devtool.ts
@@ -1,7 +1,9 @@
 /**
- * @file Integration with _Redux DevTool Extension_.
+ * Integration with _Redux DevTool Extension_.
  *
  * Please check the [docs](https://github.com/zalmoxisus/redux-devtools-extension/tree/master/docs/API) fur further information.
+ *
+ * @since 0.5.0
  */
 
 import { sequenceT } from 'fp-ts/lib/Apply'

--- a/src/Debug/redux-devtool.ts
+++ b/src/Debug/redux-devtool.ts
@@ -134,7 +134,7 @@ function handleSubscription<Model, Msg>(deps: DevToolHandlerR<Model, Msg>): (msg
 function handleIncomingMsg<Model, Msg>({
   connection,
   init,
-  data$,
+  debug$,
   dispatch
 }: DevToolHandlerR<Model, Msg>): (msg: DevToolMsg) => Either<string, IO<void>> {
   const dispatchToApp = (m: unknown): IO<void> => () => dispatch(m as Msg)
@@ -184,7 +184,7 @@ function handleIncomingMsg<Model, Msg>({
             )
 
           case 'COMMIT':
-            return E.right(restart(data$.getValue()[1]))
+            return E.right(restart(debug$.getValue()[1]))
 
           case 'IMPORT_STATE':
             return pipe(

--- a/src/Decode.ts
+++ b/src/Decode.ts
@@ -1,7 +1,9 @@
 /**
- * @file Defines a `Decoder`, namely a function that receives an `unknown` value and tries to decodes it in an `A` value.
+ * Defines a `Decoder`, namely a function that receives an `unknown` value and tries to decodes it in an `A` value.
  *
  * It returns an `Either` with a `string` as `Left` when decoding fails or an `A` as `Right` when decoding succeeds.
+ *
+ * @since 0.5.0
  */
 
 import { Alternative1 } from 'fp-ts/lib/Alternative'

--- a/src/Html.ts
+++ b/src/Html.ts
@@ -1,8 +1,10 @@
 /**
- * @file A specialization of `Program` with the capability of mapping `Model` to `View`
+ * A specialization of `Program` with the capability of mapping `Model` to `View`
  * and rendering it into a DOM node.
  *
  * `Html` is a base abstraction in order to work with any library that renders html.
+ *
+ * @since 0.5.0
  */
 
 import { Observable } from 'rxjs'

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -1,7 +1,9 @@
 /**
- * @file Makes http calls to remote resources as `Cmd`s.
+ * Makes http calls to remote resources as `Cmd`s.
  *
  * See [Http](https://package.elm-lang.org/packages/elm/http/latest/Http) Elm package.
+ *
+ * @since 0.5.0
  */
 
 import * as E from 'fp-ts/lib/Either'

--- a/src/Navigation.ts
+++ b/src/Navigation.ts
@@ -1,7 +1,9 @@
 /**
- * @file A specialization of `Program` that handles application navigation via location's hash.
+ * A specialization of `Program` that handles application navigation via location's hash.
  *
- * It uses [`history`](https://github.com/ReactTraining/history) package
+ * It uses [`history`](https://github.com/ReactTraining/history) package.
+ *
+ * @since 0.5.0
  */
 
 import * as O from 'fp-ts/lib/Option'

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -1,7 +1,9 @@
 /**
- * @file The `Platform` module is the backbone of `elm-ts`.
+ * The `Platform` module is the backbone of `elm-ts`.
  * It defines the base `program()` and `run()` functions which will be extended by more specialized modules.
  * _The Elm Architecture_ is implemented via **RxJS** `Observables`.
+ *
+ * @since 0.5.0
  */
 
 import * as O from 'fp-ts/lib/Option'

--- a/src/React.ts
+++ b/src/React.ts
@@ -1,5 +1,7 @@
 /**
- * @file A specialization of `Html` that uses `React` as renderer.
+ * A specialization of `Html` that uses `React` as renderer.
+ *
+ * @since 0.5.0
  */
 
 import { ReactElement } from 'react'

--- a/src/Sub.ts
+++ b/src/Sub.ts
@@ -1,5 +1,7 @@
 /**
- * @file Defines `Sub`s as streams of messages.
+ * Defines `Sub`s as streams of messages.
+ *
+ * @since 0.5.0
  */
 
 import { EMPTY, Observable, merge } from 'rxjs'

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,7 +1,9 @@
 /**
- * @file Handles the execution of asynchronous effectful operations.
+ * Handles the execution of asynchronous effectful operations.
  *
  * See the [Task](https://package.elm-lang.org/packages/elm/core/latest/Task) Elm package.
+ *
+ * @since 0.5.0
  */
 
 import { Either } from 'fp-ts/lib/Either'

--- a/src/Time.ts
+++ b/src/Time.ts
@@ -1,6 +1,9 @@
 /**
- * @file Exposes some utilities to work with unix time.
+ * Exposes some utilities to work with unix time.
+ *
  * See [Time](https://package.elm-lang.org/packages/elm/time/latest/Time) Elm package.
+ *
+ * @since 0.5.0
  */
 
 import { Task } from 'fp-ts/lib/Task'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * @since 0.5.0
+ */
 import * as cmd from './Cmd'
 import * as decode from './Decode'
 import * as html from './Html'

--- a/test/Cmd.test.ts
+++ b/test/Cmd.test.ts
@@ -14,7 +14,7 @@ describe('Cmd', () => {
     return input.subscribe(async to => {
       const result = await to()
 
-      assert.deepEqual(result, O.some('TEST'))
+      assert.deepStrictEqual(result, O.some('TEST'))
 
       done()
     })
@@ -26,7 +26,7 @@ describe('Cmd', () => {
     return map(a => a + 'b')(cmdA).subscribe(async to => {
       const result = await to()
 
-      assert.deepEqual(result, O.some('ab'))
+      assert.deepStrictEqual(result, O.some('ab'))
 
       done()
     })
@@ -44,7 +44,7 @@ describe('Cmd', () => {
       complete: async () => {
         const result = await sequenceTask(log)()
 
-        assert.deepEqual(result, [O.some('a'), O.some('b'), O.some('c')])
+        assert.deepStrictEqual(result, [O.some('a'), O.some('b'), O.some('c')])
 
         done()
       }

--- a/test/Debug/Html.test.ts
+++ b/test/Debug/Html.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import { EMPTY } from 'rxjs'
 import { Cmd, none } from '../../src/Cmd'
-import { programWithDebugger, programWithDebuggerWithFlags } from '../../src/Debug'
+import { programWithDebugger, programWithDebuggerWithFlags } from '../../src/Debug/Html'
 import { DebugData } from '../../src/Debug/commons'
 import * as ConsoleDebugger from '../../src/Debug/console'
 import * as DevToolDebugger from '../../src/Debug/redux-devtool'

--- a/test/Debug/Html.test.ts
+++ b/test/Debug/Html.test.ts
@@ -1,48 +1,56 @@
 import * as assert from 'assert'
-import { EMPTY } from 'rxjs'
+import { take } from 'rxjs/operators'
 import { Cmd, none } from '../../src/Cmd'
 import { programWithDebugger, programWithDebuggerWithFlags } from '../../src/Debug/Html'
 import { DebugData } from '../../src/Debug/commons'
 import * as ConsoleDebugger from '../../src/Debug/console'
 import * as DevToolDebugger from '../../src/Debug/redux-devtool'
-import { Html } from '../../src/Html'
-import { Sub } from '../../src/Sub'
+import { Html, run } from '../../src/Html'
+import * as Sub from '../../src/Sub'
+import { Model, Msg } from './_helpers'
 
 describe('Debug', () => {
-  let log: Array<DebugData<Model, Msg>> = []
+  it('programWithDebugger() should return a Program with a Debugger (console)', done => {
+    const log: Array<DebugData<Model, Msg>> = []
 
-  afterEach(() => {
-    log = []
-  })
-
-  it('programWithDebugger() should return a Program with a Debugger (console)', () => {
     // --- Trace only console debugger
     jest
       .spyOn(ConsoleDebugger, 'consoleDebugger')
       .mockReturnValueOnce(() => data => log.push(data as DebugData<Model, Msg>))
 
     const program = programWithDebugger(init, update, view)
+    const updates = run(program, _ => undefined)
 
-    program.dispatch({ tag: 'Inc' })
+    // the difference between the number of Model and the length of the debug log
+    // is due to `__DebugUpdateModel__` and `__DebugApplyMsg__` messages
+    // that generate a new Model update but are not tracked by the debugger
+    updates.pipe(take(7)).subscribe({
+      complete: () => {
+        assert.strictEqual(log.length, 5)
+        assert.deepStrictEqual(log, [
+          [{ type: 'INIT' }, 0],
+          [{ type: 'MESSAGE', payload: { type: 'Inc' } }, 1],
+          [{ type: 'MESSAGE', payload: { type: 'Dec' } }, 9],
+          [{ type: 'MESSAGE', payload: { type: 'Inc' } }, 10],
+          [{ type: 'MESSAGE', payload: { type: 'Inc' } }, 12]
+        ])
+
+        done()
+      }
+    })
+
+    program.dispatch({ type: 'Inc' })
     // we need to cast as any to test internal handling of this "special" message
     program.dispatch({ type: '__DebugUpdateModel__', payload: 10 } as any)
-    program.dispatch({ tag: 'Dec' })
-    program.dispatch({ tag: 'Inc' })
+    program.dispatch({ type: 'Dec' })
+    program.dispatch({ type: 'Inc' })
     // we need to cast as any to test internal handling of this "special" message
-    program.dispatch({ type: '__DebugApplyMsg__', payload: { tag: 'Inc' } } as any)
-    program.dispatch({ tag: 'Inc' })
-
-    assert.strictEqual(log.length, 5)
-    assert.deepStrictEqual(log, [
-      [{ type: 'INIT' }, 0],
-      [{ type: 'MESSAGE', payload: { tag: 'Inc' } }, 1],
-      [{ type: 'MESSAGE', payload: { tag: 'Dec' } }, 9],
-      [{ type: 'MESSAGE', payload: { tag: 'Inc' } }, 10],
-      [{ type: 'MESSAGE', payload: { tag: 'Inc' } }, 12]
-    ])
+    program.dispatch({ type: '__DebugApplyMsg__', payload: { type: 'Inc' } } as any)
+    program.dispatch({ type: 'Inc' })
   })
 
-  it('programWithDebugger() should return a Program with a Debugger (redux devtool)', () => {
+  it('programWithDebugger() should return a Program with a Debugger (redux devtool)', done => {
+    const log: Array<DebugData<Model, Msg>> = []
     const win = window as any
 
     // --- Mock Redux DevTool Extension
@@ -55,28 +63,40 @@ describe('Debug', () => {
       .spyOn(DevToolDebugger, 'reduxDevToolDebugger')
       .mockReturnValueOnce(() => data => log.push(data as DebugData<Model, Msg>))
 
-    const program = programWithDebugger(init, update, view, subscription)
+    const program = programWithDebugger(init, update, view, () => Sub.none)
+    const updates = run(program, _ => undefined)
 
-    program.dispatch({ tag: 'Inc' })
+    // the difference between the number of Model and the length of the debug log
+    // is due to `__DebugUpdateModel__` and `__DebugApplyMsg__` messages
+    // that generate a new Model update but are not tracked by the debugger
+    updates.pipe(take(6)).subscribe({
+      complete: () => {
+        assert.strictEqual(log.length, 5)
+        assert.deepStrictEqual(log, [
+          [{ type: 'INIT' }, 0],
+          [{ type: 'MESSAGE', payload: { type: 'Inc' } }, 1],
+          [{ type: 'MESSAGE', payload: { type: 'Dec' } }, 9],
+          [{ type: 'MESSAGE', payload: { type: 'Inc' } }, 10],
+          [{ type: 'MESSAGE', payload: { type: 'Inc' } }, 11]
+        ])
+
+        delete win.__REDUX_DEVTOOLS_EXTENSION__
+
+        done()
+      }
+    })
+
+    program.dispatch({ type: 'Inc' })
     // we need to cast as any to test internal handling of this "special" message
     program.dispatch({ type: '__DebugUpdateModel__', payload: 10 } as any)
-    program.dispatch({ tag: 'Dec' })
-    program.dispatch({ tag: 'Inc' })
-    program.dispatch({ tag: 'Inc' })
-
-    assert.strictEqual(log.length, 5)
-    assert.deepStrictEqual(log, [
-      [{ type: 'INIT' }, 0],
-      [{ type: 'MESSAGE', payload: { tag: 'Inc' } }, 1],
-      [{ type: 'MESSAGE', payload: { tag: 'Dec' } }, 9],
-      [{ type: 'MESSAGE', payload: { tag: 'Inc' } }, 10],
-      [{ type: 'MESSAGE', payload: { tag: 'Inc' } }, 11]
-    ])
-
-    delete win.__REDUX_DEVTOOLS_EXTENSION__
+    program.dispatch({ type: 'Dec' })
+    program.dispatch({ type: 'Inc' })
+    program.dispatch({ type: 'Inc' })
   })
 
-  it('programWithDebuggerWithFlags() should return a function that returns a Program with a Debugger and flags on `init`', () => {
+  it('programWithDebuggerWithFlags() should return a function that returns a Program with a Debugger and flags on `init`', done => {
+    const log: Array<DebugData<Model, Msg>> = []
+
     // --- Trace only console debugger
     jest
       .spyOn(ConsoleDebugger, 'consoleDebugger')
@@ -84,22 +104,26 @@ describe('Debug', () => {
 
     const initWithFlags = (v: number): [Model, Cmd<Msg>] => [v, none]
     const program = programWithDebuggerWithFlags(initWithFlags, update, view)(10)
+    const updates = run(program, _ => undefined)
 
-    program.dispatch({ tag: 'Inc' })
+    updates.pipe(take(2)).subscribe({
+      complete: () => {
+        assert.strictEqual(log.length, 2)
+        assert.deepStrictEqual(log, [[{ type: 'INIT' }, 10], [{ type: 'MESSAGE', payload: { type: 'Inc' } }, 11]])
 
-    assert.strictEqual(log.length, 2)
-    assert.deepStrictEqual(log, [[{ type: 'INIT' }, 10], [{ type: 'MESSAGE', payload: { tag: 'Inc' } }, 11]])
+        done()
+      }
+    })
+
+    program.dispatch({ type: 'Inc' })
   })
 })
 
 // --- Fake application
-type Model = number
-type Msg = { tag: 'Inc' } | { tag: 'Dec' }
-
 const init: [Model, Cmd<Msg>] = [0, none]
 
 const update = (msg: Msg, model: Model): [Model, Cmd<Msg>] => {
-  switch (msg.tag) {
+  switch (msg.type) {
     case 'Inc':
       return [model + 1, none]
     case 'Dec':
@@ -108,5 +132,3 @@ const update = (msg: Msg, model: Model): [Model, Cmd<Msg>] => {
 }
 
 const view = (_: Model): Html<void, Msg> => _dispatch => undefined
-
-const subscription = (_: Model): Sub<Msg> => EMPTY

--- a/test/Debug/Navigation.test.ts
+++ b/test/Debug/Navigation.test.ts
@@ -1,0 +1,168 @@
+// --- Helpers
+import * as H from '../_helpers'
+
+// --- Mocking `History` module - super tricky...
+import { mocked } from 'ts-jest/utils'
+jest.mock('history')
+import * as history from 'history'
+const historyM = mocked(history)
+
+const historyLog: string[] = []
+
+historyM.createHashHistory.mockImplementation(H.createMockHistory(historyLog))
+// --- /Mocking
+
+import * as assert from 'assert'
+import { take } from 'rxjs/operators'
+import { Cmd, none } from '../../src/Cmd'
+import { programWithDebugger, programWithDebuggerWithFlags } from '../../src/Debug/Navigation'
+import { DebugData } from '../../src/Debug/commons'
+import * as ConsoleDebugger from '../../src/Debug/console'
+import * as DevToolDebugger from '../../src/Debug/redux-devtool'
+import { Html, run } from '../../src/Html'
+import { push } from '../../src/Navigation'
+import * as Sub from '../../src/Sub'
+
+beforeEach(() => {
+  historyLog.splice(0, historyLog.length)
+})
+
+describe('Debug', () => {
+  it('programWithDebugger() should return a Program with a Debugger (console)', done => {
+    const log: Array<DebugData<Model, Msg>> = []
+
+    // --- Trace only console debugger
+    jest
+      .spyOn(ConsoleDebugger, 'consoleDebugger')
+      .mockReturnValueOnce(() => data => log.push(data as DebugData<Model, Msg>))
+
+    const program = programWithDebugger(locationToMsg, init, update, view)
+    const updates = run(program, _ => undefined)
+
+    // the difference between the number of Model updates (expressed by model$ stream)
+    // and the length of the debug log
+    // is due to `__DebugUpdateModel__` and `__DebugApplyMsg__` messages
+    // that generate a new Model update but are not tracked by the debugger
+    updates.pipe(take(9)).subscribe({
+      complete: () => {
+        assert.strictEqual(log.length, 7)
+        assert.deepStrictEqual(log, [
+          [{ type: 'INIT' }, ''],
+          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/a' } }, ''],
+          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/a' } }, '/a'],
+          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/c' } }, '/b'],
+          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/c' } }, '/c'],
+          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/e' } }, '/d'],
+          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/e' } }, '/e']
+        ])
+
+        done()
+      }
+    })
+
+    program.dispatch({ tag: 'GoTo', path: '/a' })
+    // we need to cast as any to test internal handling of this "special" message
+    program.dispatch({ type: '__DebugUpdateModel__', payload: '/b' } as any)
+    program.dispatch({ tag: 'GoTo', path: '/c' })
+    // we need to cast as any to test internal handling of this "special" message
+    program.dispatch({ type: '__DebugApplyMsg__', payload: { tag: 'Route', path: '/d' } } as any)
+    program.dispatch({ tag: 'GoTo', path: '/e' })
+  })
+
+  it('programWithDebugger() should return a Program with a Debugger (redux devtool)', done => {
+    const log: Array<DebugData<Model, Msg>> = []
+    const win = window as any
+
+    // --- Mock Redux DevTool Extension
+    win.__REDUX_DEVTOOLS_EXTENSION__ = {
+      connect: () => ({})
+    }
+
+    // --- Trace only devtool debugger
+    jest
+      .spyOn(DevToolDebugger, 'reduxDevToolDebugger')
+      .mockReturnValueOnce(() => data => log.push(data as DebugData<Model, Msg>))
+
+    const program = programWithDebugger(locationToMsg, init, update, view, () => Sub.none)
+    const updates = run(program, _ => undefined)
+
+    // the difference between the number of Model updates (expressed by model$ stream)
+    // and the length of the debug log
+    // is due to `__DebugUpdateModel__` and `__DebugApplyMsg__` messages
+    // that generate a new Model update but are not tracked by the debugger
+    updates.pipe(take(8)).subscribe({
+      complete: () => {
+        assert.strictEqual(log.length, 7)
+        assert.deepStrictEqual(log, [
+          [{ type: 'INIT' }, ''],
+          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/a' } }, ''],
+          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/a' } }, '/a'],
+          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/c' } }, '/b'],
+          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/c' } }, '/c'],
+          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/d' } }, '/c'],
+          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/d' } }, '/d']
+        ])
+
+        delete win.__REDUX_DEVTOOLS_EXTENSION__
+
+        done()
+      }
+    })
+
+    program.dispatch({ tag: 'GoTo', path: '/a' })
+    // we need to cast as any to test internal handling of this "special" message
+    program.dispatch({ type: '__DebugUpdateModel__', payload: '/b' } as any)
+    program.dispatch({ tag: 'GoTo', path: '/c' })
+    program.dispatch({ tag: 'GoTo', path: '/d' })
+  })
+
+  it('programWithDebuggerWithFlags() should return a function that returns a Program with a Debugger and flags on `init`', () => {
+    const log: Array<DebugData<Model, Msg>> = []
+
+    // --- Trace only console debugger
+    jest
+      .spyOn(ConsoleDebugger, 'consoleDebugger')
+      .mockReturnValueOnce(() => data => log.push(data as DebugData<Model, Msg>))
+
+    const initWithFlags = (flag: string) => (_: history.Location): [Model, Cmd<Msg>] => [flag, none]
+    const program = programWithDebuggerWithFlags(locationToMsg, initWithFlags, update, view)('/start')
+    const runs = run(program, _ => undefined)
+
+    runs.pipe(take(3)).subscribe({
+      complete: () => {
+        assert.strictEqual(log.length, 3)
+        assert.deepStrictEqual(log, [
+          [{ type: 'INIT' }, '/start'],
+          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/a' } }, '/start'],
+          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/a' } }, '/a']
+        ])
+      }
+    })
+
+    program.dispatch({ tag: 'GoTo', path: '/a' })
+  })
+})
+
+// --- Fake application
+type Model = string
+type Msg = { tag: 'GoTo'; path: string } | { tag: 'Route'; path: string }
+
+function locationToMsg(l: history.Location): Msg {
+  return {
+    tag: 'Route',
+    path: l.pathname
+  }
+}
+
+const init = (l: history.Location): [Model, Cmd<Msg>] => [l.pathname, none]
+
+const update = (msg: Msg, model: Model): [Model, Cmd<Msg>] => {
+  switch (msg.tag) {
+    case 'GoTo':
+      return [model, push(msg.path)]
+    case 'Route':
+      return [msg.path, none]
+  }
+}
+
+const view = (_: Model): Html<void, Msg> => _dispatch => undefined

--- a/test/Debug/Navigation.test.ts
+++ b/test/Debug/Navigation.test.ts
@@ -39,8 +39,7 @@ describe('Debug', () => {
     const program = programWithDebugger(locationToMsg, init, update, view)
     const updates = run(program, _ => undefined)
 
-    // the difference between the number of Model updates (expressed by model$ stream)
-    // and the length of the debug log
+    // the difference between the number of Model and the length of the debug log
     // is due to `__DebugUpdateModel__` and `__DebugApplyMsg__` messages
     // that generate a new Model update but are not tracked by the debugger
     updates.pipe(take(9)).subscribe({
@@ -48,25 +47,25 @@ describe('Debug', () => {
         assert.strictEqual(log.length, 7)
         assert.deepStrictEqual(log, [
           [{ type: 'INIT' }, ''],
-          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/a' } }, ''],
-          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/a' } }, '/a'],
-          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/c' } }, '/b'],
-          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/c' } }, '/c'],
-          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/e' } }, '/d'],
-          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/e' } }, '/e']
+          [{ type: 'MESSAGE', payload: { type: 'GoTo', path: '/a' } }, ''],
+          [{ type: 'MESSAGE', payload: { type: 'Route', path: '/a' } }, '/a'],
+          [{ type: 'MESSAGE', payload: { type: 'GoTo', path: '/c' } }, '/b'],
+          [{ type: 'MESSAGE', payload: { type: 'Route', path: '/c' } }, '/c'],
+          [{ type: 'MESSAGE', payload: { type: 'GoTo', path: '/e' } }, '/d'],
+          [{ type: 'MESSAGE', payload: { type: 'Route', path: '/e' } }, '/e']
         ])
 
         done()
       }
     })
 
-    program.dispatch({ tag: 'GoTo', path: '/a' })
+    program.dispatch({ type: 'GoTo', path: '/a' })
     // we need to cast as any to test internal handling of this "special" message
     program.dispatch({ type: '__DebugUpdateModel__', payload: '/b' } as any)
-    program.dispatch({ tag: 'GoTo', path: '/c' })
+    program.dispatch({ type: 'GoTo', path: '/c' })
     // we need to cast as any to test internal handling of this "special" message
-    program.dispatch({ type: '__DebugApplyMsg__', payload: { tag: 'Route', path: '/d' } } as any)
-    program.dispatch({ tag: 'GoTo', path: '/e' })
+    program.dispatch({ type: '__DebugApplyMsg__', payload: { type: 'Route', path: '/d' } } as any)
+    program.dispatch({ type: 'GoTo', path: '/e' })
   })
 
   it('programWithDebugger() should return a Program with a Debugger (redux devtool)', done => {
@@ -86,8 +85,7 @@ describe('Debug', () => {
     const program = programWithDebugger(locationToMsg, init, update, view, () => Sub.none)
     const updates = run(program, _ => undefined)
 
-    // the difference between the number of Model updates (expressed by model$ stream)
-    // and the length of the debug log
+    // the difference between the number of Model and the length of the debug log
     // is due to `__DebugUpdateModel__` and `__DebugApplyMsg__` messages
     // that generate a new Model update but are not tracked by the debugger
     updates.pipe(take(8)).subscribe({
@@ -95,12 +93,12 @@ describe('Debug', () => {
         assert.strictEqual(log.length, 7)
         assert.deepStrictEqual(log, [
           [{ type: 'INIT' }, ''],
-          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/a' } }, ''],
-          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/a' } }, '/a'],
-          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/c' } }, '/b'],
-          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/c' } }, '/c'],
-          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/d' } }, '/c'],
-          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/d' } }, '/d']
+          [{ type: 'MESSAGE', payload: { type: 'GoTo', path: '/a' } }, ''],
+          [{ type: 'MESSAGE', payload: { type: 'Route', path: '/a' } }, '/a'],
+          [{ type: 'MESSAGE', payload: { type: 'GoTo', path: '/c' } }, '/b'],
+          [{ type: 'MESSAGE', payload: { type: 'Route', path: '/c' } }, '/c'],
+          [{ type: 'MESSAGE', payload: { type: 'GoTo', path: '/d' } }, '/c'],
+          [{ type: 'MESSAGE', payload: { type: 'Route', path: '/d' } }, '/d']
         ])
 
         delete win.__REDUX_DEVTOOLS_EXTENSION__
@@ -109,11 +107,11 @@ describe('Debug', () => {
       }
     })
 
-    program.dispatch({ tag: 'GoTo', path: '/a' })
+    program.dispatch({ type: 'GoTo', path: '/a' })
     // we need to cast as any to test internal handling of this "special" message
     program.dispatch({ type: '__DebugUpdateModel__', payload: '/b' } as any)
-    program.dispatch({ tag: 'GoTo', path: '/c' })
-    program.dispatch({ tag: 'GoTo', path: '/d' })
+    program.dispatch({ type: 'GoTo', path: '/c' })
+    program.dispatch({ type: 'GoTo', path: '/d' })
   })
 
   it('programWithDebuggerWithFlags() should return a function that returns a Program with a Debugger and flags on `init`', () => {
@@ -133,23 +131,23 @@ describe('Debug', () => {
         assert.strictEqual(log.length, 3)
         assert.deepStrictEqual(log, [
           [{ type: 'INIT' }, '/start'],
-          [{ type: 'MESSAGE', payload: { tag: 'GoTo', path: '/a' } }, '/start'],
-          [{ type: 'MESSAGE', payload: { tag: 'Route', path: '/a' } }, '/a']
+          [{ type: 'MESSAGE', payload: { type: 'GoTo', path: '/a' } }, '/start'],
+          [{ type: 'MESSAGE', payload: { type: 'Route', path: '/a' } }, '/a']
         ])
       }
     })
 
-    program.dispatch({ tag: 'GoTo', path: '/a' })
+    program.dispatch({ type: 'GoTo', path: '/a' })
   })
 })
 
 // --- Fake application
 type Model = string
-type Msg = { tag: 'GoTo'; path: string } | { tag: 'Route'; path: string }
+type Msg = { type: 'GoTo'; path: string } | { type: 'Route'; path: string }
 
 function locationToMsg(l: history.Location): Msg {
   return {
-    tag: 'Route',
+    type: 'Route',
     path: l.pathname
   }
 }
@@ -157,7 +155,7 @@ function locationToMsg(l: history.Location): Msg {
 const init = (l: history.Location): [Model, Cmd<Msg>] => [l.pathname, none]
 
 const update = (msg: Msg, model: Model): [Model, Cmd<Msg>] => {
-  switch (msg.tag) {
+  switch (msg.type) {
     case 'GoTo':
       return [model, push(msg.path)]
     case 'Route':

--- a/test/Debug/_helpers.ts
+++ b/test/Debug/_helpers.ts
@@ -8,6 +8,6 @@ export const DATA$ = new BehaviorSubject<DebugData<Model, Msg>>([{ type: 'INIT' 
 
 export const STD_DEPS: DebuggerR<Model, Msg> = {
   init: 0,
-  data$: DATA$,
+  debug$: DATA$,
   dispatch: () => undefined
 }

--- a/test/Debug/commons.test.ts
+++ b/test/Debug/commons.test.ts
@@ -1,5 +1,12 @@
 import * as assert from 'assert'
-import { debugInit, debugMsg } from '../../src/Debug/commons'
+import { BehaviorSubject } from 'rxjs'
+import { DebugData, debugInit, debugMsg, runDebugger } from '../../src/Debug/commons'
+import * as ConsoleDebugger from '../../src/Debug/console'
+import * as DevToolDebugger from '../../src/Debug/redux-devtool'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
 
 describe('Debug/commons', () => {
   it('debugInit() should return a `DebugInit` object', () => {
@@ -15,4 +22,65 @@ describe('Debug/commons', () => {
       }
     })
   })
+
+  describe('runDebugger()', () => {
+    it('should run a standard console debugger when redux dev-tool is not available', () => {
+      const log: Array<DebugData<Model, Msg>> = []
+
+      // --- Mock debuggers
+      jest.spyOn(DevToolDebugger, 'reduxDevToolDebugger').mockReturnValueOnce(() => _ => undefined)
+      jest
+        .spyOn(ConsoleDebugger, 'consoleDebugger')
+        .mockReturnValueOnce(() => data => log.push(data as DebugData<Model, Msg>))
+      // ---
+
+      const Debugger = runDebugger<Model, Msg>(window)
+      const init = 0
+      const debug$ = new BehaviorSubject<DebugData<Model, Msg>>([debugInit(), init])
+      const dispatch = () => undefined
+
+      Debugger({ init, debug$, dispatch })()
+
+      debug$.next([debugMsg({ tag: 'Inc' }), 1])
+
+      assert.deepStrictEqual(log, [[debugInit(), 0], [debugMsg({ tag: 'Inc' }), 1]])
+
+      assert.strictEqual((DevToolDebugger.reduxDevToolDebugger as any).mock.calls.length, 0)
+    })
+
+    it('should run a redux dev-toll debugger when is available', () => {
+      const log: Array<DebugData<Model, Msg>> = []
+
+      // --- Mock debuggers
+      jest.spyOn(ConsoleDebugger, 'consoleDebugger').mockReturnValueOnce(() => _ => undefined)
+      jest
+        .spyOn(DevToolDebugger, 'reduxDevToolDebugger')
+        .mockReturnValueOnce(() => data => log.push(data as DebugData<Model, Msg>))
+      // ---
+
+      const win = window as any
+
+      // --- Mock Redux DevTool Extension
+      win.__REDUX_DEVTOOLS_EXTENSION__ = {
+        connect: () => ({})
+      }
+
+      const Debugger = runDebugger<Model, Msg>(win)
+      const init = 0
+      const debug$ = new BehaviorSubject<DebugData<Model, Msg>>([debugInit(), init])
+      const dispatch = () => undefined
+
+      Debugger({ init, debug$, dispatch })()
+
+      debug$.next([debugMsg({ tag: 'Inc' }), 1])
+
+      assert.deepStrictEqual(log, [[debugInit(), 0], [debugMsg({ tag: 'Inc' }), 1]])
+
+      assert.strictEqual((ConsoleDebugger.consoleDebugger as any).mock.calls.length, 0)
+    })
+  })
 })
+
+// --- Helpers
+type Model = number
+type Msg = { tag: 'Inc' } | { tag: 'Dec' }

--- a/test/Debug/redux-devtool.test.ts
+++ b/test/Debug/redux-devtool.test.ts
@@ -144,14 +144,14 @@ describe('Debug/redux-dev-tool', () => {
 
     it('should handle "COMMIT" message from extension', () => {
       const init = connection.init as jest.Mock<any, any>
-      const data$ = new BehaviorSubject<DebugData<Model, Msg>>([{ type: 'INIT' }, 0])
-      reduxDevToolDebugger(connection)({ ...STD_DEPS, data$ })
+      const debug$ = new BehaviorSubject<DebugData<Model, Msg>>([{ type: 'INIT' }, 0])
+      reduxDevToolDebugger(connection)({ ...STD_DEPS, debug$ })
 
       // Add some values in data$ stream to simulate a "living" application
-      data$.next([{ type: 'MESSAGE', payload: { type: 'Inc' } }, 1])
-      data$.next([{ type: 'MESSAGE', payload: { type: 'Inc' } }, 2])
-      data$.next([{ type: 'MESSAGE', payload: { type: 'Inc' } }, 3])
-      data$.next([{ type: 'MESSAGE', payload: { type: 'Dec' } }, 2])
+      debug$.next([{ type: 'MESSAGE', payload: { type: 'Inc' } }, 1])
+      debug$.next([{ type: 'MESSAGE', payload: { type: 'Inc' } }, 2])
+      debug$.next([{ type: 'MESSAGE', payload: { type: 'Inc' } }, 3])
+      debug$.next([{ type: 'MESSAGE', payload: { type: 'Dec' } }, 2])
 
       emit({ type: 'DISPATCH', payload: { type: 'COMMIT' } })
 

--- a/test/Navigation.test.ts
+++ b/test/Navigation.test.ts
@@ -1,50 +1,15 @@
+// --- Helpers
+import * as H from './_helpers'
+
 // --- Mocking `History` module - super tricky...
 import { mocked } from 'ts-jest/utils'
 jest.mock('history')
 import * as history from 'history'
 const historyM = mocked(history)
 
-let log: string[] = []
-let listener: history.LocationListener
+const log: string[] = []
 
-historyM.createHashHistory.mockImplementation(() => ({
-  location: {
-    pathname: log.length > 0 ? log[log.length - 1] : '',
-    search: '',
-    state: null,
-    hash: ''
-  },
-
-  push: (path: string | history.LocationDescriptorObject): void => {
-    const p = typeof path === 'string' ? path : typeof path.pathname !== 'undefined' ? path.pathname : ''
-    log.push(p)
-
-    listener(
-      {
-        pathname: p,
-        search: '',
-        state: null,
-        hash: ''
-      },
-      'PUSH'
-    )
-  },
-
-  listen: (fn: history.History.LocationListener): history.UnregisterCallback => {
-    listener = fn
-    return () => undefined
-  },
-
-  // These are needed by `history` types declaration
-  length: log.length,
-  action: 'PUSH',
-  replace: () => undefined,
-  go: () => undefined,
-  goBack: () => undefined,
-  goForward: () => undefined,
-  block: () => () => undefined,
-  createHref: () => ''
-}))
+historyM.createHashHistory.mockImplementation(H.createMockHistory(log))
 // --- /Mocking
 
 import * as assert from 'assert'
@@ -55,10 +20,9 @@ import { Cmd, none } from '../src/Cmd'
 import { Html } from '../src/Html'
 import { Location, program, programWithFlags, push } from '../src/Navigation'
 import { Sub } from '../src/Sub'
-import * as H from './_helpers'
 
 beforeEach(() => {
-  log = []
+  log.splice(0, log.length)
 })
 
 afterAll(() => {

--- a/test/Sub.test.ts
+++ b/test/Sub.test.ts
@@ -21,7 +21,7 @@ describe('Sub', () => {
       next: v => log.push(v),
 
       complete: () => {
-        assert.deepEqual(log, ['a', 'b', 'c'])
+        assert.deepStrictEqual(log, ['a', 'b', 'c'])
 
         done()
       }

--- a/test/_helpers.ts
+++ b/test/_helpers.ts
@@ -1,5 +1,6 @@
 import { some } from 'fp-ts/lib/Option'
 import { task } from 'fp-ts/lib/Task'
+import { History, LocationDescriptorObject, LocationListener, UnregisterCallback } from 'history'
 import { EMPTY, Observable, of } from 'rxjs'
 import * as cmd from '../src/Cmd'
 import { Html } from '../src/Html'
@@ -89,3 +90,50 @@ export const delayedAssert = (f: () => void, delay: number = 50): Promise<void> 
       }
     }, delay)
   })
+
+// --- History
+/**
+ * Creates a mocked implementation of the `history.createHashHistory()` function that tracks location changes through the `log` parameter
+ */
+export function createMockHistory(log: string[]): () => History {
+  let listener: LocationListener
+
+  return () => ({
+    location: {
+      pathname: log.length > 0 ? log[log.length - 1] : '',
+      search: '',
+      state: null,
+      hash: ''
+    },
+
+    push: (path: string | LocationDescriptorObject): void => {
+      const p = typeof path === 'string' ? path : typeof path.pathname !== 'undefined' ? path.pathname : ''
+      log.push(p)
+
+      listener(
+        {
+          pathname: p,
+          search: '',
+          state: null,
+          hash: ''
+        },
+        'PUSH'
+      )
+    },
+
+    listen: (fn: History.LocationListener): UnregisterCallback => {
+      listener = fn
+      return () => undefined
+    },
+
+    // These are needed by `history` types declaration
+    length: log.length,
+    action: 'PUSH',
+    replace: () => undefined,
+    go: () => undefined,
+    goBack: () => undefined,
+    goForward: () => undefined,
+    block: () => () => undefined,
+    createHref: () => ''
+  })
+}


### PR DESCRIPTION
This PR:

- adds a new specialization of `programWithDebugger` and `programWithDebuggerWithFlags` for `Navigation` (`Debug/Navigation.ts`)
- moves `Html` specialization in a specific module (`Debug/Html.ts`)
- deprecates importing `programWithDebugger` and `programWithDebuggerWithFlags` from `Debug/index.ts`
- upgrades `docs-ts` version to 0.3.0 and fixes jsdoc annotations
- adds colorful console messages for project scripts