### PR TITLE
fix emission of initial commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+## 0.5.6
+
+- **Bug Fix:**
+  - fix emission of initial commands in the `cmd$` stream of `Program`
+
 ## 0.5.5
 
 - **Bug Fix:**

--- a/docs/modules/Decode.ts.md
+++ b/docs/modules/Decode.ts.md
@@ -59,7 +59,7 @@ Added in v0.5.0
 **Signature**
 
 ```ts
-export const URI: "Decoder" = ...
+export const URI: "elm-ts/Decoder" = ...
 ```
 
 Added in v0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-ts",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-ts",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A porting of TEA to TypeScript featuring fp-ts, rxjs6 and React",
   "files": [
     "lib",

--- a/src/Decode.ts
+++ b/src/Decode.ts
@@ -15,21 +15,21 @@ import { pipeable } from 'fp-ts/lib/pipeable'
 // --- Aliases for docs
 import ReaderEither = RE.ReaderEither
 
-declare module 'fp-ts/lib/HKT' {
-  interface URItoKind<A> {
-    Decoder: Decoder<A>
-  }
-}
-
 /**
  * @since 0.5.0
  */
-export const URI = 'Decoder'
+export const URI = 'elm-ts/Decoder'
 
 /**
  * @since 0.5.0
  */
 export type URI = typeof URI
+
+declare module 'fp-ts/lib/HKT' {
+  interface URItoKind<A> {
+    readonly [URI]: Decoder<A>
+  }
+}
 
 /**
  * @since 0.5.0

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -8,7 +8,7 @@
 
 import * as O from 'fp-ts/lib/Option'
 import { BehaviorSubject, Observable } from 'rxjs'
-import { distinctUntilChanged, map, mergeAll, switchMap, takeUntil } from 'rxjs/operators'
+import { distinctUntilChanged, map, mergeAll, startWith, switchMap, takeUntil } from 'rxjs/operators'
 import { Cmd } from './Cmd'
 import { Sub, none } from './Sub'
 
@@ -48,6 +48,7 @@ export function program<Model, Msg>(
   const dispatch: Dispatch<Msg> = msg => state$.next(update(msg, state$.getValue()[0]))
 
   const cmd$ = state$.pipe(
+    startWith(init), // This is needed to avoid swallowing of initial commands in some situations
     map(state => state[1]),
     distinctUntilChanged(),
     mergeAll()

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -59,7 +59,10 @@ export function program<Model, Msg>(
     distinctUntilChanged()
   )
 
-  const sub$ = model$.pipe(switchMap(model => subscriptions(model)))
+  const sub$ = model$.pipe(
+    startWith(init[0]), // This is needed to avoid swallowing of initial model in some situations
+    switchMap(model => subscriptions(model))
+  )
 
   return { dispatch, cmd$, sub$, model$ }
 }

--- a/test/Html.test.ts
+++ b/test/Html.test.ts
@@ -101,6 +101,7 @@ describe('Html', () => {
 
   describe('run()', () => {
     it('should run the Program', () => {
+      // setup
       const renderings: string[] = []
       const renderer = (dom: H.SimplerDom) => {
         renderings.push(`<${dom.tag}>${dom.text}</${dom.tag}>`)
@@ -108,13 +109,16 @@ describe('Html', () => {
       const view = (model: H.Model) => H.span(model.x)
       const p = program(H.init, H.update, view, H.subscriptions)
 
+      // run
       run(p, renderer)
 
+      // dispatch
       p.dispatch({ type: 'FOO' })
       p.dispatch({ type: 'SUB' })
       p.dispatch({ type: 'BAR' })
       p.dispatch({ type: 'DO-THE-THING!' })
 
+      // assert
       return H.delayedAssert(() => {
         assert.deepStrictEqual(renderings, [
           '<span></span>',
@@ -127,7 +131,47 @@ describe('Html', () => {
       })
     })
 
+    it('should run the Program with initial Model and Cmds', () => {
+      // setup
+      const renderings: string[] = []
+      const renderer = (dom: H.SimplerDom) => {
+        renderings.push(`<${dom.tag}>${dom.text}</${dom.tag}>`)
+      }
+      const view = (model: H.Model) => H.span(model.x)
+      const p = program(H.initWithCmd, H.update, view, H.subscriptions)
+
+      // run
+      run(p, renderer)
+
+      // dispatch
+      // --- setTimeout in order to simulate a real application use
+      const to = setTimeout(() => {
+        p.dispatch({ type: 'FOO' })
+        p.dispatch({ type: 'SUB' })
+        p.dispatch({ type: 'BAR' })
+        p.dispatch({ type: 'DO-THE-THING!' })
+
+        clearTimeout(to)
+      }, 50)
+
+      // assert
+      return H.delayedAssert(() => {
+        assert.deepStrictEqual(renderings, [
+          '<span>init</span>',
+          '<span>foo</span>',
+          '<span>bar</span>',
+          '<span>foo</span>',
+          '<span>foo</span>',
+          '<span>sub</span>',
+          '<span>listen</span>',
+          '<span>bar</span>',
+          '<span>foo</span>'
+        ])
+      }, 100)
+    })
+
     it('should stop the Program when signal is emitted', () => {
+      // setup
       const signal = new Subject<any>()
 
       const renderings: string[] = []
@@ -137,8 +181,10 @@ describe('Html', () => {
       const view = (model: H.Model) => H.span(model.x)
       const p = withStop(signal)(program(H.init, H.update, view, H.subscriptions))
 
+      // run
       run(p, renderer)
 
+      // dispatch
       p.dispatch({ type: 'FOO' })
       p.dispatch({ type: 'SUB' })
       p.dispatch({ type: 'BAR' })
@@ -152,6 +198,7 @@ describe('Html', () => {
       p.dispatch({ type: 'BAR' })
       p.dispatch({ type: 'DO-THE-THING!' })
 
+      // assert
       return H.delayedAssert(() => {
         assert.deepStrictEqual(renderings, [
           '<span></span>',

--- a/test/_helpers.ts
+++ b/test/_helpers.ts
@@ -13,6 +13,11 @@ export interface Model {
 
 export const init: [Model, cmd.Cmd<Msg>] = [{ x: '' }, cmd.none]
 
+export const initWithCmd: [Model, cmd.Cmd<Msg>] = [
+  { x: 'init' },
+  cmd.batch<Msg>([cmd.of({ type: 'FOO' }), cmd.of({ type: 'DO-THE-THING!' }), cmd.of({ type: 'BAR' })])
+]
+
 // --- Messages
 export type Msg = { type: 'FOO' } | { type: 'BAR' } | { type: 'DO-THE-THING!' } | { type: 'SUB' } | { type: 'LISTEN' }
 


### PR DESCRIPTION
This PR fixes the emission of initial commands in the `cmd$` and initial model in the `sub$` streams of `Program` that are "swallowed" in some situations.

Related to #10 and #11 