### PR TITLE
add a namespace to Decoder URI in order to avoid name collision

### DIFF
--- a/docs/modules/Decode.ts.md
+++ b/docs/modules/Decode.ts.md
@@ -59,7 +59,7 @@ Added in v0.5.0
 **Signature**
 
 ```ts
-export const URI: "Decoder" = ...
+export const URI: "elm-ts/Decoder" = ...
 ```
 
 Added in v0.5.0

--- a/src/Decode.ts
+++ b/src/Decode.ts
@@ -15,21 +15,21 @@ import { pipeable } from 'fp-ts/lib/pipeable'
 // --- Aliases for docs
 import ReaderEither = RE.ReaderEither
 
-declare module 'fp-ts/lib/HKT' {
-  interface URItoKind<A> {
-    Decoder: Decoder<A>
-  }
-}
-
 /**
  * @since 0.5.0
  */
-export const URI = 'Decoder'
+export const URI = 'elm-ts/Decoder'
 
 /**
  * @since 0.5.0
  */
 export type URI = typeof URI
+
+declare module 'fp-ts/lib/HKT' {
+  interface URItoKind<A> {
+    readonly [URI]: Decoder<A>
+  }
+}
 
 /**
  * @since 0.5.0


### PR DESCRIPTION
This PR adds a namespace to `Decoder`'s HKT uri in order to avoid name collision with other libraries in the `fp-ts` ecosystem (like the new [`Decoder`](https://github.com/gcanti/io-ts/blob/master/src/Decoder.ts) module of `io-ts`)

@gcanti it should also bumped the package's version (at least a patch)