### PR TITLE
rename imported type to avoid conflict with local

### DIFF
--- a/src/Decode.ts
+++ b/src/Decode.ts
@@ -1,8 +1,8 @@
 import { Either } from 'fp-ts/lib/Either'
-import { Type, mixed } from 'io-ts'
+import { Type, mixed as ioMixed } from 'io-ts'
 import { failure } from 'io-ts/lib/PathReporter'
 
-export type mixed = mixed
+export type mixed = ioMixed
 
 export interface Decoder<a> {
   decode: (value: mixed) => Either<string, a>


### PR DESCRIPTION
This unblocks legacy 0.4 version to work with 3.7+ version of typescript (fixes [this TS breaking change](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#local-and-imported-type-declarations-now-conflict))

@gcanti can you please release this simple change as new 0.4 version since I'm stuck on it, but need latest TS to work :(