### PR TITLE
Original XMLHttpRequest object in response

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,10 +3,5 @@
   "prettier.printWidth": 120,
   "prettier.semi": false,
   "prettier.singleQuote": true,
-  "tslint.enable": true,
-  "[typescript]": {
-    "editor.codeActionsOnSave": {
-      "source.organizeImports": false
-    }
-  }
+  "tslint.enable": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,10 @@
   "prettier.printWidth": 120,
   "prettier.semi": false,
   "prettier.singleQuote": true,
-  "tslint.enable": true
+  "tslint.enable": true,
+  "[typescript]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": false
+    }
+  }
 }

--- a/docs/modules/Http.ts.md
+++ b/docs/modules/Http.ts.md
@@ -28,6 +28,7 @@ Added in v0.5.0
   - [Response (interface)](#response-interface)
 - [utils](#utils)
   - [send](#send)
+  - [sendWithResp](#sendwithresp)
 
 ---
 
@@ -138,6 +139,20 @@ Executes as `Cmd` the provided call to remote resource, mapping result to a `Msg
 
 ```ts
 export declare function send<A, Msg>(f: (e: Either<HttpError, A>) => Msg): (req: Request<A>) => Cmd<Msg>
+```
+
+Added in v0.5.0
+
+## sendWithResp
+
+Executes as `Cmd` the provided call to remote resource, mapping result to a `Msg` containing the full response.
+
+**Signature**
+
+```ts
+export declare function sendWithResp<A, Msg>(
+  f: (e: Either<HttpError, Response<A>>) => Msg
+): (req: Request<A>) => Cmd<Msg>
 ```
 
 Added in v0.5.0

--- a/docs/modules/Http.ts.md
+++ b/docs/modules/Http.ts.md
@@ -26,8 +26,10 @@ Added in v0.5.0
   - [Method (type alias)](#method-type-alias)
   - [Request (interface)](#request-interface)
   - [Response (interface)](#response-interface)
+  - [ResponseAndXHR (interface)](#responseandxhr-interface)
 - [utils](#utils)
   - [send](#send)
+  - [sendFull](#sendfull)
 
 ---
 
@@ -128,6 +130,19 @@ export interface Response<Body> {
 
 Added in v0.5.0
 
+## ResponseAndXHR (interface)
+
+**Signature**
+
+```ts
+export interface ResponseAndXHR<A> {
+  xhr: XMLHttpRequest
+  response: Response<A>
+}
+```
+
+Added in v0.5.8
+
 # utils
 
 ## send
@@ -141,3 +156,17 @@ export declare function send<A, Msg>(f: (e: Either<HttpError, A>) => Msg): (req:
 ```
 
 Added in v0.5.0
+
+## sendFull
+
+Executes as `Cmd` the provided call to remote resource, mapping result to a `Msg` containing the full response and the original XMLHTTPRequest object.
+
+**Signature**
+
+```ts
+export declare function sendFull<A, Msg>(
+  f: (e: Either<HttpError, ResponseAndXHR<A>>) => Msg
+): (req: Request<A>) => Cmd<Msg>
+```
+
+Added in v0.5.8

--- a/docs/modules/Http.ts.md
+++ b/docs/modules/Http.ts.md
@@ -28,7 +28,6 @@ Added in v0.5.0
   - [Response (interface)](#response-interface)
 - [utils](#utils)
   - [send](#send)
-  - [sendWithResp](#sendwithresp)
 
 ---
 
@@ -124,7 +123,6 @@ export interface Response<Body> {
   }
   headers: Record<string, string>
   body: Body
-  xhr: XMLHttpRequest
 }
 ```
 
@@ -140,20 +138,6 @@ Executes as `Cmd` the provided call to remote resource, mapping result to a `Msg
 
 ```ts
 export declare function send<A, Msg>(f: (e: Either<HttpError, A>) => Msg): (req: Request<A>) => Cmd<Msg>
-```
-
-Added in v0.5.0
-
-## sendWithResp
-
-Executes as `Cmd` the provided call to remote resource, mapping result to a `Msg` containing the full response.
-
-**Signature**
-
-```ts
-export declare function sendWithResp<A, Msg>(
-  f: (e: Either<HttpError, Response<A>>) => Msg
-): (req: Request<A>) => Cmd<Msg>
 ```
 
 Added in v0.5.0

--- a/docs/modules/Http.ts.md
+++ b/docs/modules/Http.ts.md
@@ -124,6 +124,7 @@ export interface Response<Body> {
   }
   headers: Record<string, string>
   body: Body
+  xhr: XMLHttpRequest
 }
 ```
 

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -55,6 +55,7 @@ export interface Response<Body> {
   }
   headers: Record<string, string>
   body: Body
+  xhr: XMLHttpRequest
 }
 
 /**
@@ -68,12 +69,14 @@ export type HttpError =
   | { readonly _tag: 'BadStatus'; readonly response: Response<string> }
   | { readonly _tag: 'BadPayload'; readonly value: string; readonly response: Response<string> }
 
+type XHR<A> = Observable<Either<HttpError, Response<A>>>
+
 /**
  * @category destructors
  * @since 0.5.0
  */
 export function toTask<A>(req: Request<A>): TaskEither<HttpError, A> {
-  return () => xhr(req).toPromise()
+  return () => toResult(xhr(req)).toPromise()
 }
 
 /**
@@ -82,7 +85,7 @@ export function toTask<A>(req: Request<A>): TaskEither<HttpError, A> {
  * @since 0.5.0
  */
 export function send<A, Msg>(f: (e: Either<HttpError, A>) => Msg): (req: Request<A>) => Cmd<Msg> {
-  return req => xhr(req).pipe(map(result => T.of(O.some(f(result)))))
+  return req => toResult(xhr(req)).pipe(map(result => T.of(O.some(f(result)))))
 }
 
 /**
@@ -91,7 +94,7 @@ export function send<A, Msg>(f: (e: Either<HttpError, A>) => Msg): (req: Request
  * @since 0.5.0
  */
 export function sendWithResp<A, Msg>(f: (e: Either<HttpError, Response<A>>) => Msg): (req: Request<A>) => Cmd<Msg> {
-  return req => xhrWithResp(req).pipe(map(result => T.of(O.some(f(result)))))
+  return req => xhr(req).pipe(map(result => T.of(O.some(f(result)))))
 }
 
 /**
@@ -127,15 +130,15 @@ export function post<A>(url: string, body: unknown, decoder: Decoder<A>): Reques
 }
 
 // --- Helpers
-function xhrWithResp<A>(req: Request<A>): Observable<Either<HttpError, Response<A>>> {
-  return ajax(toXHRRequest(req)).pipe(
-    map(flow(toResponse(req), decodeWithAsResp(req.expect))),
-    catchError((e: unknown): Observable<Either<HttpError, Response<A>>> => of(E.left(toHttpError(req, e))))
-  )
+function toResult<A>(x: XHR<A>): Observable<Either<HttpError, A>> {
+  return x.pipe(map(E.map(resp => resp.body)))
 }
 
-function xhr<A>(req: Request<A>): Observable<Either<HttpError, A>> {
-  return xhrWithResp(req).pipe(map(E.map(_ => _.body)))
+function xhr<A>(req: Request<A>): XHR<A> {
+  return ajax(toXHRRequest(req)).pipe(
+    map(flow(toResponse(req), decodeWith(req.expect))),
+    catchError((e: unknown): XHR<A> => of(E.left(toHttpError(req, e))))
+  )
 }
 
 function toXHRRequest<A>(req: Request<A>): AjaxRequest {
@@ -150,34 +153,30 @@ function toXHRRequest<A>(req: Request<A>): AjaxRequest {
   }
 }
 
-function parseResponseHeaders(rawRespHeaders: string): Record<string, string> {
-  return rawRespHeaders.split('\r\n').reduce((acc, current) => {
-    const parts = current.split(':').filter(_ => _.length > 0)
-    return parts.length === 2 ? { ...acc, [parts[0].trim()]: parts[1].trim() } : acc
-  }, {})
-}
-
 function toResponse<A>(req: Request<A>): (resp: AjaxResponse) => Response<string> {
   return resp => ({
     url: req.url,
     status: { code: resp.status, message: '' },
-    headers: parseResponseHeaders(resp.xhr.getAllResponseHeaders()),
-    body: typeof resp.response === 'string' && resp.response.length > 0 ? resp.response : '{}'
+    headers: req.headers,
+    body: typeof resp.response === 'string' && resp.response.length > 0 ? resp.response : '{}',
+    xhr: resp.xhr
   })
 }
 
-function decodeWithAsResp<A>(decoder: Decoder<A>): (resp: Response<string>) => Either<HttpError, Response<A>> {
+function decodeWith<A>(decoder: Decoder<A>): (resp: Response<string>) => Either<HttpError, Response<A>> {
   return resp =>
     pipe(
       // By spec parsing json can only throw `SyntaxError`
       E.parseJSON(resp.body, e => (e as SyntaxError).message),
       E.chain(decoder),
-      E.map(body => ({ ...resp, body })),
-      E.mapLeft(e => ({
-        _tag: 'BadPayload',
-        value: e,
-        response: resp
-      }))
+      E.bimap(
+        e => ({
+          _tag: 'BadPayload',
+          value: e,
+          response: resp
+        }),
+        body => ({ ...resp, body })
+      )
     )
 }
 
@@ -197,7 +196,8 @@ function toHttpError<A>(req: Request<A>, e: unknown): HttpError {
         url: req.url,
         status: { code: e.status, message: '' },
         headers: req.headers,
-        body: e.response
+        body: e.response,
+        xhr: e.xhr
       }
     }
   }

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -152,7 +152,7 @@ function toXHRRequest<A>(req: Request<A>): AjaxRequest {
 
 function parseResponseHeaders(rawRespHeaders: string): Record<string, string> {
   return rawRespHeaders.split('\r\n').reduce((acc, current) => {
-    const parts = current.split(':').filter(_ => _ !== null)
+    const parts = current.split(':').filter(_ => _.length > 0)
     return parts.length === 2 ? { ...acc, [parts[0].trim()]: parts[1].trim() } : acc
   }, {})
 }

--- a/test/Http.test.ts
+++ b/test/Http.test.ts
@@ -45,8 +45,7 @@ describe('Http', () => {
             url: 'http://example.com/test',
             status: { code: 200, message: '' },
             headers: {},
-            body,
-            xhr: server.requests[0]
+            body
           }
         })
       )
@@ -76,8 +75,7 @@ describe('Http', () => {
             url: 'http://example.com/test',
             status: { code: 500, message: '' },
             headers: {},
-            body,
-            xhr: server.requests[0]
+            body
           }
         })
       )
@@ -166,8 +164,7 @@ describe('Http', () => {
             url: 'http://example.com/test',
             status: { code: 200, message: '' },
             headers: {},
-            body,
-            xhr: server.requests[0]
+            body
           }
         })
       )
@@ -221,8 +218,7 @@ describe('Http', () => {
                 url: 'http://example.com/test',
                 status: { code: 500, message: '' },
                 headers: {},
-                body,
-                xhr: server.requests[0]
+                body
               }
             }
           })
@@ -231,72 +227,18 @@ describe('Http', () => {
         done()
       })
     })
-  })
 
-  describe('sendWithResp()', () => {
-    let server: sinon.SinonFakeServer
+    it('should request an http call and return a Cmd - EMPTY', done => {
+      server.respondWith('GET', 'http://example.com/test', [204, {}, ''])
 
-    beforeEach(() => {
-      server = sinon.fakeServer.create({ respondImmediately: true })
-    })
+      const request = Http.send(E.fold(msg, msg))
 
-    afterEach(() => {
-      server.restore()
-    })
-
-    it('should request an http call and return a Cmd - OK', done => {
-      server.respondWith('GET', 'http://example.com/test', [200, {}, JSON.stringify({ a: 'test' })])
-
-      const request = Http.sendWithResp(E.fold(msg, msg))
-
-      const cmd = request(Http.get('http://example.com/test', fromCodec(t.type({ a: t.string }))))
+      const cmd = request(Http.get('http://example.com/test', fromCodec(t.UnknownRecord)))
 
       return cmd.subscribe(async to => {
         const result = await to()
 
-        assert.deepStrictEqual(
-          result,
-          some({
-            payload: {
-              url: 'http://example.com/test',
-              status: { code: 200, message: '' },
-              headers: {},
-              body: { a: 'test' },
-              xhr: server.requests[0]
-            }
-          })
-        )
-
-        done()
-      })
-    })
-
-    it('should request an http call and return a Cmd - KO', done => {
-      const body = JSON.stringify({ error: 'bad response' })
-      server.respondWith('GET', 'http://example.com/test', [500, {}, body])
-
-      const request = Http.sendWithResp(E.fold(msg, msg))
-
-      const cmd = request(Http.get('http://example.com/test', fromCodec(t.string)))
-
-      return cmd.subscribe(async to => {
-        const result = await to()
-
-        assert.deepStrictEqual(
-          result,
-          some({
-            payload: {
-              _tag: 'BadStatus',
-              response: {
-                url: 'http://example.com/test',
-                status: { code: 500, message: '' },
-                headers: {},
-                body,
-                xhr: server.requests[0]
-              }
-            }
-          })
-        )
+        assert.deepStrictEqual(result, some({ payload: {} }))
 
         done()
       })


### PR DESCRIPTION
@StefanoMagrassi I added the xhr to the response object via the new sendFull function as per the other PR.

The only issue I can see is that the Error state can't get access to it. Not sure how much of an issue that is.
